### PR TITLE
Add long-press "Select" handlebar gesture (default: Assistant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ the mirroring link — so you must **pair the phone to the bike over Bluetooth**
 | --- | --- |
 | **Backward** — ◀ left, or ▲ volume on non-touch dashes | Rotary knob back (previous item) |
 | **Forward** — ▶ right, or ▼ volume on non-touch dashes | Rotary knob forward (next item) |
-| **Select** — Enter / ★ (start) button | Select / OK |
+| **Select** — Enter / ★ (start) button, quick tap | Select / OK |
+| **Select (hold)** — press and hold Enter / ★ | Assistant (voice) |
 | **Backward ×2** (double-tap, non-touch dashes) | Home (app list) |
 | **Forward ×2** (double-tap, non-touch dashes) | Back |
 

--- a/app/src/main/java/dev/zanderp/opencfmoto/ButtonMap.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/ButtonMap.kt
@@ -50,7 +50,11 @@ enum class ButtonAction(val id: String, val label: String) {
  *   • **Backward/Forward ×2** — a double-tap. Only the volume dashes can signal it (one coalesced
  *     volume write with a bigger jump); the 800MT's discrete track keys just repeat the single step,
  *     so these rows are effectively non-touch-dash only.
- *   • **Select** — the OK / ★ (start) button, which every dash sends as an AVRCP play/pause.
+ *   • **Select** — the OK / ★ (start) button, which every dash sends as an AVRCP play/pause. A quick
+ *     tap is [SELECT_PRESS]; holding it past [MediaButtonBridge]'s long-press threshold is
+ *     [SELECT_LONG]. The two are told apart by the gap between the button's key-down and key-up on the
+ *     media-button path, so long-press only works on dashes that send a distinct release (the ▲/▼
+ *     volume path has no release event, so it has no long-press).
  *
  * [label] is the semantic name (with the physical buttons that trigger it); [hint] explains it.
  */
@@ -62,7 +66,8 @@ enum class ButtonGesture(
 ) {
     NAV_BACK("navBack", "Backward  ◀ / ▲", "◀ left, or the ▲ volume press on non-touch dashes", ButtonAction.KNOB_BACK),
     NAV_FWD("navFwd", "Forward  ▶ / ▼", "▶ right, or the ▼ volume press on non-touch dashes", ButtonAction.KNOB_FORWARD),
-    SELECT_PRESS("selectPress", "Select  Enter / ★", "the OK / ★ start button (dash sends play-pause)", ButtonAction.SELECT),
+    SELECT_PRESS("selectPress", "Select  Enter / ★", "a quick tap of the OK / ★ start button (dash sends play-pause)", ButtonAction.SELECT),
+    SELECT_LONG("selectLong", "Select (hold)  Enter / ★", "press and hold the OK / ★ button", ButtonAction.ASSISTANT),
     NAV_BACK_DOUBLE("navBackDouble", "Backward ×2", "double-tap backward — non-touch dashes only", ButtonAction.HOME),
     NAV_FWD_DOUBLE("navFwdDouble", "Forward ×2", "double-tap forward — non-touch dashes only", ButtonAction.BACK),
 }

--- a/app/src/main/java/dev/zanderp/opencfmoto/ButtonMappingActivity.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/ButtonMappingActivity.kt
@@ -160,7 +160,7 @@ class ButtonMappingActivity : AppCompatActivity() {
             .setTitle("Reset to defaults?")
             .setMessage(
                 "Every gesture goes back to how it shipped: ▲/▼ press = knob, ▲▲ = home, " +
-                    "▼▼ = back, enter = select.\n\nSaved places are kept."
+                    "▼▼ = back, enter tap = select, enter hold = voice.\n\nSaved places are kept."
             )
             .setPositiveButton("Reset") { _, _ ->
                 ButtonMap.resetAll(this)

--- a/app/src/main/java/dev/zanderp/opencfmoto/MediaButtonBridge.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/MediaButtonBridge.kt
@@ -19,6 +19,7 @@ import android.media.session.MediaSession
 import android.media.session.PlaybackState
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.provider.Settings
 import android.view.KeyEvent
 import dev.zanderp.opencfmoto.aa.AaInput
@@ -146,6 +147,7 @@ class MediaButtonBridge(private val context: Context, private val log: (String) 
                 if (on) takeMediaFocus() else releaseMediaFocus()
                 session?.isActive = on
                 if (on) pinVolume() else unpinVolume()
+                if (!on) selectDownAt = 0L   // drop any half-finished press when handing buttons back
                 log("[BTN] capture ${if (on) "ON — bike buttons drive Android Auto (music pauses)" else "OFF — buttons control media/volume"}")
             } catch (e: Exception) {
                 log("[BTN] setCaptureActive failed: $e")
@@ -192,7 +194,7 @@ class MediaButtonBridge(private val context: Context, private val log: (String) 
             session?.setMetadata(
                 MediaMetadata.Builder()
                     .putString(MediaMetadata.METADATA_KEY_TITLE, "Android Auto control")
-                    .putString(MediaMetadata.METADATA_KEY_ARTIST, "◀ ▶ / ▲ ▼ navigate · Enter selects")
+                    .putString(MediaMetadata.METADATA_KEY_ARTIST, "◀ ▶ / ▲ ▼ navigate · Enter selects · hold Enter = voice")
                     .putString(MediaMetadata.METADATA_KEY_ALBUM, "OpenCfMoto")
                     .putLong(MediaMetadata.METADATA_KEY_DURATION, TRACK_MS)
                     .build()
@@ -396,37 +398,69 @@ class MediaButtonBridge(private val context: Context, private val log: (String) 
     private val callback = object : MediaSession.Callback() {
         override fun onMediaButtonEvent(mediaButtonIntent: Intent): Boolean {
             @Suppress("DEPRECATION")
-            val ke = mediaButtonIntent.getParcelableExtra<KeyEvent>(Intent.EXTRA_KEY_EVENT)
-            if (ke != null && ke.action == KeyEvent.ACTION_DOWN) {
-                log("[BTN] media key ${KeyEvent.keyCodeToString(ke.keyCode)} (code=${ke.keyCode})")
-                forward(ke.keyCode)
+            val ke = mediaButtonIntent.getParcelableExtra<KeyEvent>(Intent.EXTRA_KEY_EVENT) ?: return true
+            when (ke.action) {
+                KeyEvent.ACTION_DOWN -> {
+                    val repeat = if (ke.repeatCount > 0) " repeat=${ke.repeatCount}" else ""
+                    log("[BTN] media key ${KeyEvent.keyCodeToString(ke.keyCode)} down (code=${ke.keyCode})$repeat")
+                    onKeyDown(ke.keyCode)
+                }
+                KeyEvent.ACTION_UP -> onKeyUp(ke.keyCode)
             }
             return true
         }
-        // Fallbacks: the bike takes the raw-key path above; other dashes / BT remotes may dispatch here.
+        // Fallbacks: the bike takes the raw-key path above; other dashes / BT remotes may dispatch
+        // here. These carry no hold timing, so they can only ever be a short press.
         override fun onPlay() = run(ButtonGesture.SELECT_PRESS)
         override fun onPause() = run(ButtonGesture.SELECT_PRESS)
     }
 
+    /** elapsedRealtime of the select button's key-down while it's held; 0 when nothing is pressed. */
+    private var selectDownAt = 0L
+
+    private fun isSelectKey(keyCode: Int) = when (keyCode) {
+        KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
+        KeyEvent.KEYCODE_MEDIA_PLAY,
+        KeyEvent.KEYCODE_MEDIA_PAUSE -> true
+        else -> false
+    }
+
     /**
-     * Map a raw media keycode to a gesture:
-     *   • play/pause → enter (select) — every dash sends this on the enter/OK button.
+     * Map a raw media key-down to a gesture:
+     *   • play/pause → the enter/OK button. We don't fire yet: a tap is [ButtonGesture.SELECT_PRESS]
+     *     and a hold is [ButtonGesture.SELECT_LONG], and we can only tell them apart once the button is
+     *     released (see [onKeyUp]). We just stamp when it went down (ignoring auto-repeat downs).
      *   • next-/previous-track → the ▶/◀ presses of the 800MT's 5-way joystick (verified on hardware:
      *     right = KEYCODE_MEDIA_NEXT, left = KEYCODE_MEDIA_PREVIOUS). The 3-button CFDL16 dashes never
-     *     emit these, so wiring them up is harmless there.
+     *     emit these, so wiring them up is harmless there. These fire on down (they have no long-press).
      * Anything else is logged and dropped — aliasing an unknown key onto a real action would be a
      * nasty surprise when that action is "navigate home".
      */
-    private fun forward(keyCode: Int) {
-        when (keyCode) {
-            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
-            KeyEvent.KEYCODE_MEDIA_PLAY,
-            KeyEvent.KEYCODE_MEDIA_PAUSE -> run(ButtonGesture.SELECT_PRESS)
-            KeyEvent.KEYCODE_MEDIA_NEXT,
-            KeyEvent.KEYCODE_MEDIA_FAST_FORWARD -> run(ButtonGesture.NAV_FWD)
-            KeyEvent.KEYCODE_MEDIA_PREVIOUS,
-            KeyEvent.KEYCODE_MEDIA_REWIND -> run(ButtonGesture.NAV_BACK)
+    private fun onKeyDown(keyCode: Int) {
+        when {
+            isSelectKey(keyCode) -> { if (selectDownAt == 0L) selectDownAt = SystemClock.elapsedRealtime() }
+            keyCode == KeyEvent.KEYCODE_MEDIA_NEXT ||
+                keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD -> run(ButtonGesture.NAV_FWD)
+            keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS ||
+                keyCode == KeyEvent.KEYCODE_MEDIA_REWIND -> run(ButtonGesture.NAV_BACK)
         }
+    }
+
+    /**
+     * Select button released: how long it was held decides the gesture. Held past [LONG_PRESS_MS] →
+     * [ButtonGesture.SELECT_LONG], otherwise a normal [ButtonGesture.SELECT_PRESS]. An UP with no
+     * matching DOWN (e.g. capture turned on mid-press) falls back to a short press so select never
+     * silently does nothing.
+     */
+    private fun onKeyUp(keyCode: Int) {
+        if (!isSelectKey(keyCode)) return
+        val downAt = selectDownAt
+        selectDownAt = 0L
+        if (downAt == 0L) { run(ButtonGesture.SELECT_PRESS); return }
+        val heldMs = SystemClock.elapsedRealtime() - downAt
+        val long = heldMs >= LONG_PRESS_MS
+        log("[BTN] select held ${heldMs}ms → ${if (long) "long press" else "tap"}")
+        run(if (long) ButtonGesture.SELECT_LONG else ButtonGesture.SELECT_PRESS)
     }
 
     companion object {
@@ -440,6 +474,14 @@ class MediaButtonBridge(private val context: Context, private val log: (String) 
          * a dash calibrates differently, that log line is what to re-read.
          */
         private const val DOUBLE_TAP_STEPS = 3
+
+        /**
+         * How long the select button must be held to count as a long press rather than a tap. A touch
+         * above Android's own 500 ms long-press timeout, to leave margin for a gloved, deliberate hold
+         * and keep ordinary taps from tripping it. The actual hold is logged on every release, so this
+         * is the number to re-read if a dash times differently.
+         */
+        private const val LONG_PRESS_MS = 600L
 
         private const val REASSERT_POLL_MS = 1_000L
         private const val REASSERT_GIVEUP_MS = 90_000L


### PR DESCRIPTION
## What & why

Non-touch CFDL16 riders drive Android Auto with the handlebar buttons, but the enter/OK/★ button only ever produced one action ("Select"). Handlebar buttons reach the app as a fake-media-player capture, and enter arrives on the media-key path as AVRCP play/pause. `MediaButtonBridge` acted on `ACTION_DOWN` and **discarded `ACTION_UP`**, so there was no way to get a second action out of the one button these riders have.

This adds a distinct **long-press** gesture on that button.

## Changes

- **New `ButtonGesture.SELECT_LONG`** ("Select (hold)"), default action **Assistant (voice)**. Mapping rows are generated from `ButtonGesture.entries`, so it appears in *Customize buttons* automatically and is remappable to any action (knob / D-pad / back / home / navigate-to-a-saved-place / nothing), read live on each press.
- **`MediaButtonBridge` now uses the key-up it used to drop:** stamps the select button's down-time and, on release, fires `SELECT_LONG` when held ≥ 600 ms, otherwise the existing `SELECT_PRESS`. Auto-repeat downs are ignored; an UP with no matching DOWN falls back to a short press so select never silently no-ops; a half-finished press is cleared when capture is handed back to media. Every release logs the measured hold (`[BTN] select held NNNms → …`).
- Docs/copy: README gesture table, the reset-to-defaults dialog, and the on-dash "now playing" hint.

## Reviewer notes

- **Long-press is Enter/★ only, by design.** The ▲/▼ path used by non-touch dashes delivers absolute-volume writes with **no release event**, so there is nothing to time there.
- **Runtime is unverified on hardware** — compiled clean (`:app:compileDebugKotlin`) but I couldn't press a real bike button. The logic depends on the dash sending a distinct down **and** up for enter; the strongest evidence it does is that the previous code deliberately filtered out `ACTION_UP`. If a dash sends only one event, select still works as a tap via the fallback. The new hold-time log line is what confirms it on a bike.
- 600 ms threshold sits just above Android's 500 ms long-press timeout to leave margin for a gloved, deliberate hold; it's a single named constant if it needs tuning.
