### PR TITLE
1.0.10: adaptive video tuning (thermal + link), idle throttle & Wi-Fi locks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "dev.zanderp.opencfmoto"
         minSdk = 29
         targetSdk = 36
-        versionCode = 10
-        versionName = "1.0.9"
+        versionCode = 11
+        versionName = "1.0.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/zanderp/opencfmoto/AdaptiveVideoController.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/AdaptiveVideoController.kt
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Alexandru <https://alexandru.rocks> and the OpenCfMoto contributors.
+// Part of OpenCfMoto. Free software under the GNU AGPL v3 or later; see LICENSE and NOTICE.
+package dev.zanderp.opencfmoto
+
+import android.content.Context
+import android.os.PowerManager
+
+/**
+ * Pure adaptation math for [PowerMode.AUTO] (no Android dependencies, so it is unit-testable).
+ *
+ * Two independent pressures pull the video quality down, and the more aggressive one wins:
+ *  - **Thermal** (idea 1): the phone's `PowerManager` thermal status maps to a bitrate factor and an
+ *    fps cap. This is a safety response — a hot phone stutters and eventually thermal-throttles the
+ *    encoder/Wi-Fi, so we pre-emptively shed load and keep the dash smooth-at-a-lower-rate.
+ *  - **Link** (idea 2): sustained encoded-frame drops mean the bike can't pull as fast as we encode
+ *    (Wi-Fi congestion / distance). We back the bitrate off multiplicatively and recover it additively
+ *    (AIMD, like TCP), so marginal links degrade to a softer picture instead of hitting the bike's
+ *    media-socket timeout and dropping the whole projection.
+ *
+ * The two combine on bitrate by taking the smaller factor; fps is driven by thermal only (the link
+ * fix is fewer bits per frame, not fewer frames).
+ */
+data class AdaptiveDecision(val bitrate: Int, val fps: Int, val linkFactor: Float)
+
+object AdaptivePolicy {
+    /** AIMD bounds for the link factor. */
+    const val LINK_MIN = 0.4f          // never shed more than 60% for link reasons alone
+    const val LINK_MAX = 1.0f          // recover up to (never past) the user's target
+    const val LINK_DECREASE = 0.8f     // multiplicative back-off on a congested tick
+    const val LINK_INCREASE_STEP = 0.05f // additive recovery on a clean tick
+
+    /** Encoded-frame drops within one tick window at/above which the link counts as congested. */
+    const val DROP_CONGESTION_THRESHOLD = 8
+
+    /** Absolute bitrate floor (bps) — below this the map is too soft to be useful, so we stop shedding. */
+    const val MIN_BITRATE = 600_000
+
+    /** Bitrate multiplier for a given `PowerManager` thermal status (THERMAL_STATUS_*). */
+    fun thermalBitrateFactor(status: Int): Float = when {
+        status <= PowerManager.THERMAL_STATUS_LIGHT -> 1.0f     // NONE / LIGHT: no throttle
+        status == PowerManager.THERMAL_STATUS_MODERATE -> 0.8f
+        status == PowerManager.THERMAL_STATUS_SEVERE -> 0.6f
+        else -> 0.5f                                            // CRITICAL / EMERGENCY / SHUTDOWN
+    }
+
+    /** fps cap for a given thermal status, never above the mode's starting [baseFps]. */
+    fun thermalFpsCap(status: Int, baseFps: Int): Int = when {
+        status <= PowerManager.THERMAL_STATUS_LIGHT -> baseFps
+        status == PowerManager.THERMAL_STATUS_MODERATE -> minOf(baseFps, 20)
+        status == PowerManager.THERMAL_STATUS_SEVERE -> minOf(baseFps, 15)
+        else -> minOf(baseFps, 12)
+    }
+
+    /** AIMD step: shrink hard on congestion, grow gently when clean. */
+    fun nextLinkFactor(prev: Float, dropsThisTick: Int): Float =
+        if (dropsThisTick >= DROP_CONGESTION_THRESHOLD)
+            (prev * LINK_DECREASE).coerceAtLeast(LINK_MIN)
+        else
+            (prev + LINK_INCREASE_STEP).coerceAtMost(LINK_MAX)
+
+    /**
+     * Compute the next decision from the current inputs and the previous link factor. Deterministic
+     * and side-effect-free — the controller owns the state, this owns the arithmetic.
+     */
+    fun decide(
+        baseBitrate: Int,
+        baseFps: Int,
+        thermalStatus: Int,
+        prevLinkFactor: Float,
+        dropsThisTick: Int,
+    ): AdaptiveDecision {
+        val link = nextLinkFactor(prevLinkFactor, dropsThisTick)
+        val factor = minOf(thermalBitrateFactor(thermalStatus), link)
+        val bitrate = (baseBitrate * factor).toInt().coerceIn(MIN_BITRATE.coerceAtMost(baseBitrate), baseBitrate)
+        val fps = thermalFpsCap(thermalStatus, baseFps)
+        return AdaptiveDecision(bitrate, fps, link)
+    }
+}
+
+/**
+ * Runs [AdaptivePolicy] against the live [VideoPipeline] once per watchdog tick (see
+ * [AndroidAutoService]). Only active while the rider has chosen [PowerMode.AUTO]; the fixed power
+ * modes short-circuit it entirely, so their behaviour is byte-for-byte unchanged.
+ */
+class AdaptiveVideoController(
+    private val context: Context,
+    private val log: (String) -> Unit,
+) {
+    private val powerManager by lazy {
+        context.applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+    }
+
+    private var linkFactor = AdaptivePolicy.LINK_MAX
+    private var lastDropTotal = 0L
+    private var appliedBitrate = -1
+    private var appliedFps = -1
+    /** True once we have adapted this session, so a switch away from AUTO can restore the fixed rate. */
+    private var adapting = false
+
+    /** New session (or resume): forget prior link state so we start fresh at the user's target. */
+    fun reset() {
+        linkFactor = AdaptivePolicy.LINK_MAX
+        lastDropTotal = 0L
+        appliedBitrate = -1
+        appliedFps = -1
+        adapting = false
+    }
+
+    fun onTick(pipeline: VideoPipeline?) {
+        val pipe = pipeline ?: return
+
+        if (VideoPrefs.power(context) != PowerMode.AUTO) {
+            // Rider switched to a fixed mode mid-session: hand the rate back once, then stay out.
+            if (adapting) restoreFixed(pipe)
+            return
+        }
+
+        val base = pipe.targetBitrate()
+        if (base <= 0) return   // encoder not created yet (pre-canvas)
+
+        val status = try { powerManager.currentThermalStatus } catch (_: Exception) {
+            PowerManager.THERMAL_STATUS_NONE
+        }
+
+        val total = pipe.droppedFramesTotal()
+        val dropsThisTick = (total - lastDropTotal).coerceAtLeast(0L).toInt()
+        lastDropTotal = total
+
+        val d = AdaptivePolicy.decide(
+            baseBitrate = base,
+            baseFps = PowerMode.AUTO.fps,
+            thermalStatus = status,
+            prevLinkFactor = linkFactor,
+            dropsThisTick = dropsThisTick,
+        )
+        linkFactor = d.linkFactor
+
+        if (d.bitrate != appliedBitrate) {
+            pipe.setEncoderBitrate(d.bitrate)
+            appliedBitrate = d.bitrate
+            adapting = true
+            log("[adaptive] thermal=${thermalName(status)} drops/tick=$dropsThisTick link=${pct(linkFactor)} → ${d.bitrate / 1000}kbps")
+        }
+        if (d.fps != appliedFps) {
+            pipe.setFrameCap(d.fps)
+            appliedFps = d.fps
+            adapting = true
+            log("[adaptive] thermal=${thermalName(status)} → ${d.fps}fps")
+        }
+    }
+
+    /** Restore the pipeline to the (now-fixed) power mode's rate and stop adapting. */
+    private fun restoreFixed(pipe: VideoPipeline) {
+        val base = pipe.targetBitrate()
+        if (base > 0) pipe.setEncoderBitrate(base)
+        pipe.setFrameCap(VideoPrefs.power(context).fps)
+        log("[adaptive] AUTO off — restored to ${VideoPrefs.power(context).label}")
+        reset()
+    }
+
+    private fun pct(f: Float) = "${(f * 100).toInt()}%"
+
+    private fun thermalName(status: Int) = when (status) {
+        PowerManager.THERMAL_STATUS_NONE -> "none"
+        PowerManager.THERMAL_STATUS_LIGHT -> "light"
+        PowerManager.THERMAL_STATUS_MODERATE -> "moderate"
+        PowerManager.THERMAL_STATUS_SEVERE -> "severe"
+        PowerManager.THERMAL_STATUS_CRITICAL -> "critical"
+        PowerManager.THERMAL_STATUS_EMERGENCY -> "emergency"
+        PowerManager.THERMAL_STATUS_SHUTDOWN -> "shutdown"
+        else -> "?$status"
+    }
+}

--- a/app/src/main/java/dev/zanderp/opencfmoto/AndroidAutoService.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/AndroidAutoService.kt
@@ -38,6 +38,9 @@ class AndroidAutoService : Service() {
     private val watchdogHandler = Handler(Looper.getMainLooper())
     private var lastRecoveryAt = 0L
 
+    // Adaptive video tuning (PowerMode.AUTO): thermal + link-driven bitrate/fps, run each watchdog tick.
+    private val adaptive by lazy { AdaptiveVideoController(applicationContext, LogBus::log) }
+
     // Hybrid reconnect supervisor state (see tickReconnectSupervisor / parkAa / doResume).
     @Volatile private var aaParked = false          // AA torn down to save battery while bike is gone
     @Volatile private var sawStream = false         // we reached STREAMING at least once this session
@@ -74,6 +77,7 @@ class AndroidAutoService : Service() {
                 if (!isRunning) return
                 try { tickReconnectSupervisor() } catch (_: Exception) {}
                 try { tickWatchdog() } catch (_: Exception) {}
+                try { adaptive.onTick(pipeline) } catch (_: Exception) {}
                 try { tickTripLogging() } catch (_: Exception) {}
                 watchdogHandler.postDelayed(this, WATCHDOG_TICK_MS)
             }
@@ -322,6 +326,7 @@ class AndroidAutoService : Service() {
             }
             pipeline = vp
             AaVideoBridge.pipeline = vp
+            adaptive.reset()   // fresh session: start adaptation from the user's target
             receiver = AaReceiver(applicationContext, surface, LogBus::log).also {
                 it.onSessionEnded = { userExit -> onAaSessionEnded(userExit) }
                 it.start()

--- a/app/src/main/java/dev/zanderp/opencfmoto/AndroidAutoService.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/AndroidAutoService.kt
@@ -13,6 +13,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
+import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Handler
 import android.os.IBinder
@@ -35,6 +36,13 @@ class AndroidAutoService : Service() {
     private var receiver: AaReceiver? = null
     private var mediaButtons: MediaButtonBridge? = null
     private var wakeLock: PowerManager.WakeLock? = null
+    // Wi-Fi locks that keep the bike link fast for the whole streaming session (see [acquireWifiLocks]).
+    // Two are held on purpose: LOW_LATENCY only engages while the app is foreground AND the screen is
+    // on, but riders are told to ride with the screen OFF — so HIGH_PERF (which holds regardless of
+    // screen state) is the workhorse that keeps Wi-Fi out of power-save while pocketed, and LOW_LATENCY
+    // adds extra latency reduction when the Dash view is open / riding screen-on.
+    private var wifiLockLowLatency: WifiManager.WifiLock? = null
+    private var wifiLockHighPerf: WifiManager.WifiLock? = null
     private val watchdogHandler = Handler(Looper.getMainLooper())
     private var lastRecoveryAt = 0L
 
@@ -164,6 +172,7 @@ class AndroidAutoService : Service() {
         try { pipeline?.stop() } catch (_: Exception) {}
         pipeline = null
         try { if (wakeLock?.isHeld == true) wakeLock?.release() } catch (_: Exception) {}
+        releaseWifiLocks()   // parked: let the radio idle again while we wait for the bike
     }
 
     private fun parkAa() {
@@ -193,7 +202,7 @@ class AndroidAutoService : Service() {
         // Reset the trailing detail (the park set it to "will resume…") back to the bike name so it
         // doesn't linger onto STREAMING as "Connected … — will resume when the bike is back".
         ConnectionState.set(Phase.STARTING_AA, BikeMemory.lastBikeName(applicationContext) ?: "")
-        reacquireWakeLock()
+        reacquireLocks()
         updateNotification("OpenCfMoto — Android Auto", "Reconnecting to the bike dash…")
 
         startReceiver()
@@ -232,7 +241,8 @@ class AndroidAutoService : Service() {
         postResumeFallbackNotification()
     }
 
-    private fun reacquireWakeLock() {
+    /** (Re)acquire every lock the streaming session needs to stay alive backgrounded / screen-off. */
+    private fun reacquireLocks() {
         try {
             if (wakeLock == null) {
                 val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
@@ -241,6 +251,41 @@ class AndroidAutoService : Service() {
             }
             if (wakeLock?.isHeld != true) wakeLock?.acquire(4 * 60 * 60 * 1000L)
         } catch (_: Exception) {}
+        acquireWifiLocks()
+    }
+
+    /**
+     * Hold Wi-Fi locks so the bike link doesn't drop into power-save mid-ride. A streaming session is
+     * real-time video over the bike AP with the phone screen off — exactly when Android would otherwise
+     * park the radio between beacons and add latency/jitter. HIGH_PERF keeps Wi-Fi awake regardless of
+     * screen state (the screen-off case); LOW_LATENCY additionally cuts latency while foreground +
+     * screen-on. Both are safe no-ops when Wi-Fi isn't the active transport. Released on park/stop so a
+     * parked bike lets the radio idle again.
+     */
+    private fun acquireWifiLocks() {
+        try {
+            val wm = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            if (wifiLockLowLatency == null) {
+                wifiLockLowLatency = wm.createWifiLock(
+                    WifiManager.WIFI_MODE_FULL_LOW_LATENCY, "OpenCfMoto:LowLatency",
+                ).apply { setReferenceCounted(false) }
+            }
+            if (wifiLockHighPerf == null) {
+                @Suppress("DEPRECATION") // deprecated but still the reliable screen-off, no-power-save mode
+                val mode = WifiManager.WIFI_MODE_FULL_HIGH_PERF
+                wifiLockHighPerf = wm.createWifiLock(mode, "OpenCfMoto:HighPerf")
+                    .apply { setReferenceCounted(false) }
+            }
+            var acquired = false
+            if (wifiLockLowLatency?.isHeld != true) { wifiLockLowLatency?.acquire(); acquired = true }
+            if (wifiLockHighPerf?.isHeld != true) { wifiLockHighPerf?.acquire(); acquired = true }
+            if (acquired) LogBus.log("[AA] Wi-Fi locks held (high-perf + low-latency) — keeping the bike link hot")
+        } catch (_: Exception) {}
+    }
+
+    private fun releaseWifiLocks() {
+        try { if (wifiLockLowLatency?.isHeld == true) wifiLockLowLatency?.release() } catch (_: Exception) {}
+        try { if (wifiLockHighPerf?.isHeld == true) wifiLockHighPerf?.release() } catch (_: Exception) {}
     }
 
     private fun ensureChannel() {
@@ -305,8 +350,8 @@ class AndroidAutoService : Service() {
             startForeground(NOTIF_ID, notification)
         }
 
-        reacquireWakeLock()
-        LogBus.log("[AA] foreground service up (wake lock held)")
+        reacquireLocks()
+        LogBus.log("[AA] foreground service up (wake + Wi-Fi locks held)")
     }
 
     private fun startReceiver() {
@@ -396,6 +441,9 @@ class AndroidAutoService : Service() {
         pipeline = null
         try { if (wakeLock?.isHeld == true) wakeLock?.release() } catch (_: Exception) {}
         wakeLock = null
+        releaseWifiLocks()
+        wifiLockLowLatency = null
+        wifiLockHighPerf = null
         LogBus.log("[AA] foreground service stopped")
         super.onDestroy()
     }
@@ -432,11 +480,11 @@ class AndroidAutoService : Service() {
 
         /**
          * The foreground ([MainActivity]) is taking over the resume (it will rebuild AA itself), so drop
-         * the parked flag and reacquire the wake lock — otherwise the supervisor/Wi-Fi hooks would fight
+         * the parked flag and reacquire the locks — otherwise the supervisor/Wi-Fi hooks would fight
          * the foreground path.
          */
         fun notifyForegroundResuming() {
-            active?.let { it.aaParked = false; it.wifiDownSince = 0L; it.reacquireWakeLock() }
+            active?.let { it.aaParked = false; it.wifiDownSince = 0L; it.reacquireLocks() }
         }
 
         const val ACTION_STOP = "dev.zanderp.opencfmoto.ACTION_STOP_AA"

--- a/app/src/main/java/dev/zanderp/opencfmoto/SetupActivity.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/SetupActivity.kt
@@ -76,6 +76,7 @@ class SetupActivity : AppCompatActivity() {
         findViewById<MaterialButton>(R.id.fit_fill).setOnClickListener { setFit(ScreenFit.FILL) }
         findViewById<MaterialButton>(R.id.fit_fit).setOnClickListener { setFit(ScreenFit.FIT) }
         findViewById<MaterialButton>(R.id.fit_stretch).setOnClickListener { setFit(ScreenFit.STRETCH) }
+        findViewById<MaterialButton>(R.id.power_auto).setOnClickListener { setPower(PowerMode.AUTO) }
         findViewById<MaterialButton>(R.id.power_smooth).setOnClickListener { setPower(PowerMode.SMOOTH) }
         findViewById<MaterialButton>(R.id.power_balanced).setOnClickListener { setPower(PowerMode.BALANCED) }
         findViewById<MaterialButton>(R.id.power_saver).setOnClickListener { setPower(PowerMode.SAVER) }
@@ -200,6 +201,7 @@ class SetupActivity : AppCompatActivity() {
             R.id.fit_fit to ScreenFit.FIT,
             R.id.fit_stretch to ScreenFit.STRETCH)
         highlight(power,
+            R.id.power_auto to PowerMode.AUTO,
             R.id.power_smooth to PowerMode.SMOOTH,
             R.id.power_balanced to PowerMode.BALANCED,
             R.id.power_saver to PowerMode.SAVER)

--- a/app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt
@@ -63,6 +63,16 @@ class VideoPipeline(
     private var encoderH = 0
     @Volatile private var running = false
 
+    // The bitrate the encoder was configured with (the user's target). Adaptive tuning scales DOWN
+    // from this; it is the ceiling. 0 until the encoder is created.
+    @Volatile private var baseBitrate = 0
+    // The bitrate currently applied to the running encoder (via live setParameters).
+    @Volatile private var currentBitrate = 0
+    // Monotonic count of encoded frames dropped because the queue was full (the bike couldn't pull
+    // them fast enough). A rising count is the downstream-congestion signal the adaptive controller
+    // uses to back the bitrate off. See [droppedFramesTotal] and [AdaptiveVideoController].
+    @Volatile private var droppedFrames = 0L
+
     private val frameQueue = LinkedBlockingDeque<ByteArray>(8)
     @Volatile private var codecConfig: ByteArray? = null   // SPS/PPS
     // When set, the drain loop discards encoder output until the next keyframe, so the first frame a
@@ -122,7 +132,13 @@ class VideoPipeline(
                 // Surface-input encoders only emit on new buffers; a STATIC screen (e.g. mirror of
                 // an idle app) then produces zero frames and the bike times out. Repeat the last
                 // frame if nothing new arrives so output is continuous even when the screen is still.
-                setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, 100_000L) // 100ms → ≥10fps floor
+                // The floor is deliberately LOW frequency: AaCompositor already re-emits a static
+                // frame every ~2s (IDLE_REDRAW_MS) to hold the bike's ~9s media-socket timeout, so the
+                // encoder only needs a backstop below that timeout — not a 10fps re-encode of an
+                // unchanging map, which was pure wasted heat/battery (see docs/06-OPTIMIZATION-IDEAS.md
+                // idea 5). At real frame rates the compositor delivers new buffers well before this
+                // fires, so it never caps motion.
+                setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, IDLE_ENCODER_REPEAT_US)
                 // Force strictly-ascending output with no B-frame reordering: the bike wire format
                 // sends raw access units with NO timestamps, so a decoder that received reordered
                 // (B-)frames could never reassemble display order → black/garbage. Baseline already
@@ -152,6 +168,7 @@ class VideoPipeline(
             inputSurface = c.createInputSurface()
             c.start()
             codec = c
+            baseBitrate = bitrate; currentBitrate = bitrate
             encoderW = w; encoderH = h
             log("[VIDEO] encoder started ${w}x${h} h264 ${profile.videoFrameRate}fps ${bitrate / 1000}kbps (${VideoPrefs.get(context).name.lowercase()})")
             maybeStartDump()
@@ -281,10 +298,13 @@ class VideoPipeline(
                         if (isKey) awaitKeyframe = false
                         val out = if (isKey && codecConfig != null) codecConfig!! + bytes else bytes
                         writeDump(out)
-                        // Keep the queue fresh: if full, drop oldest so we never lag far behind.
+                        // Keep the queue fresh: if full, drop oldest so we never lag far behind. A
+                        // sustained drop rate means the bike can't pull as fast as we encode
+                        // (downstream/Wi-Fi congestion) — counted for the adaptive controller.
                         if (!frameQueue.offerLast(out)) {
                             frameQueue.pollFirst()
                             frameQueue.offerLast(out)
+                            droppedFrames++
                         }
                     }
                 }
@@ -300,6 +320,46 @@ class VideoPipeline(
      * after [start].
      */
     fun encoderInputSurface(): android.view.Surface? = inputSurface
+
+    /**
+     * The bitrate the encoder was configured with (the user's target for this session). This is the
+     * ceiling the adaptive controller scales down from; 0 before the encoder exists.
+     */
+    fun targetBitrate(): Int = baseBitrate
+
+    /** Monotonic count of encoded frames dropped due to a full queue (downstream congestion signal). */
+    fun droppedFramesTotal(): Long = droppedFrames
+
+    /**
+     * Live-adjust the running encoder's target bitrate (no codec re-create) via [MediaCodec.setParameters].
+     * Used by [AdaptiveVideoController] to shed bits when the phone is hot or the Wi-Fi link is
+     * congested, and to restore them as conditions recover. Clamped to (0, [baseBitrate]] so it can
+     * never exceed the user's chosen target. No-op if unchanged or the encoder isn't up yet.
+     */
+    fun setEncoderBitrate(bps: Int) {
+        val c = codec ?: return
+        if (baseBitrate <= 0) return
+        val clamped = bps.coerceIn(1, baseBitrate)
+        if (clamped == currentBitrate) return
+        try {
+            c.setParameters(android.os.Bundle().apply {
+                putInt(MediaCodec.PARAMETER_KEY_VIDEO_BITRATE, clamped)
+            })
+            currentBitrate = clamped
+            log("[VIDEO] bitrate → ${clamped / 1000}kbps (target ${baseBitrate / 1000}kbps)")
+        } catch (e: Exception) {
+            log("[VIDEO] setEncoderBitrate failed: $e")
+        }
+    }
+
+    /**
+     * Live-adjust how many frames/sec the compositor pushes into the encoder (compositor mode only).
+     * Delegates to [AaCompositor.setFrameCap]; used by [AdaptiveVideoController] to drop the rate as
+     * the phone heats up. No-op outside compositor mode.
+     */
+    fun setFrameCap(fps: Int) {
+        aaCompositor?.setFrameCap(fps)
+    }
 
     /** Compositor mode: the surface the AA decoder renders into (letterboxed before the encoder). */
     fun decoderInputSurface(): android.view.Surface? = aaCompositor?.inputSurface
@@ -407,6 +467,15 @@ class VideoPipeline(
     }
 
     companion object {
+        /**
+         * Encoder's static-screen frame-repeat floor (µs). Must stay comfortably under the bike's ~9s
+         * media-socket timeout so an unchanging map still holds the link, but far slower than the old
+         * 100ms/10fps value which re-encoded a still screen ~10× more than needed. AaCompositor's ~2s
+         * idle redraw is the primary keep-alive; this is the encoder-side backstop. See idea 5 in
+         * docs/06-OPTIMIZATION-IDEAS.md.
+         */
+        const val IDLE_ENCODER_REPEAT_US = 900_000L   // 0.9s → ≈1fps floor on a static screen
+
         /** Diagnostic build flag: dump the H.264 we send to the bike (bounded). Turn on to capture a
          *  .h264 of the exact wire stream for offline ffprobe analysis; off for normal use. */
         const val DUMP_H264 = false

--- a/app/src/main/java/dev/zanderp/opencfmoto/VideoPrefs.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/VideoPrefs.kt
@@ -35,10 +35,17 @@ enum class ScreenFit(val label: String) {
  * frame is one fewer GPU composite + hardware encode + Wi-Fi transmit, so lowering it directly cuts
  * heat and battery drain. Below the cap the map still looks fluid; the trade is a touch less
  * smoothness on fast pans. Independent of the idle keep-alive (which drops far lower still).
+ *
+ * [AUTO] hands frame rate AND bitrate to [AdaptiveVideoController]: it starts smooth and steps both
+ * down as the phone heats up (thermal status) or the bike Wi-Fi link congests (dropped frames),
+ * then recovers as conditions ease — so the dash stays connected and smooth-at-a-lower-rate instead
+ * of stuttering or dropping. [fps] here is the *starting* cap the controller adapts from. The fixed
+ * modes disable the controller entirely and pin the rate, exactly as before.
  */
 enum class PowerMode(val fps: Int, val label: String) {
+    AUTO(30, "Auto — adapts to heat & signal (recommended)"),
     SMOOTH(30, "Smooth — 30 fps (most battery)"),
-    BALANCED(24, "Balanced — 24 fps (recommended)"),
+    BALANCED(24, "Balanced — 24 fps"),
     SAVER(20, "Battery saver — 20 fps (coolest)"),
 }
 
@@ -100,8 +107,8 @@ object VideoPrefs {
     }
 
     fun power(ctx: Context): PowerMode {
-        val name = BikeScope.getString(prefs(ctx), ctx, KEY_POWER, PowerMode.BALANCED.name)
-        return runCatching { PowerMode.valueOf(name!!) }.getOrDefault(PowerMode.BALANCED)
+        val name = BikeScope.getString(prefs(ctx), ctx, KEY_POWER, PowerMode.AUTO.name)
+        return runCatching { PowerMode.valueOf(name!!) }.getOrDefault(PowerMode.AUTO)
     }
 
     fun setPower(ctx: Context, mode: PowerMode) {

--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -587,11 +587,20 @@
                     android:orientation="horizontal">
 
                     <com.google.android.material.button.MaterialButton
-                        android:id="@+id/power_smooth"
+                        android:id="@+id/power_auto"
                         style="@style/Widget.OpenCfMoto.Segment"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginEnd="4dp"
+                        android:layout_weight="1"
+                        android:text="Auto" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/power_smooth"
+                        style="@style/Widget.OpenCfMoto.Segment"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="4dp"
                         android:layout_weight="1"
                         android:text="Smooth" />
 

--- a/app/src/test/java/dev/zanderp/opencfmoto/AdaptivePolicyTest.kt
+++ b/app/src/test/java/dev/zanderp/opencfmoto/AdaptivePolicyTest.kt
@@ -1,0 +1,110 @@
+package dev.zanderp.opencfmoto
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [AdaptivePolicy] — the pure adaptation math behind [PowerMode.AUTO]. The thermal
+ * status ints are the real `PowerManager.THERMAL_STATUS_*` values (0=NONE … 6=SHUTDOWN), which are
+ * compile-time constants so this runs on the host JVM with no Android runtime.
+ */
+class AdaptivePolicyTest {
+
+    private val base = 2_500_000   // a typical target bitrate
+    private val baseFps = 30
+
+    // ── thermal → bitrate factor ─────────────────────────────────────────────────────────────────
+
+    @Test fun thermal_none_and_light_do_not_throttle() {
+        assertEquals(1.0f, AdaptivePolicy.thermalBitrateFactor(0), 0f) // NONE
+        assertEquals(1.0f, AdaptivePolicy.thermalBitrateFactor(1), 0f) // LIGHT
+    }
+
+    @Test fun thermal_steps_down_as_it_heats() {
+        assertEquals(0.8f, AdaptivePolicy.thermalBitrateFactor(2), 0f) // MODERATE
+        assertEquals(0.6f, AdaptivePolicy.thermalBitrateFactor(3), 0f) // SEVERE
+        assertEquals(0.5f, AdaptivePolicy.thermalBitrateFactor(4), 0f) // CRITICAL
+        assertEquals(0.5f, AdaptivePolicy.thermalBitrateFactor(6), 0f) // SHUTDOWN
+    }
+
+    // ── thermal → fps cap ────────────────────────────────────────────────────────────────────────
+
+    @Test fun fps_cap_full_when_cool_then_drops() {
+        assertEquals(30, AdaptivePolicy.thermalFpsCap(0, baseFps))
+        assertEquals(30, AdaptivePolicy.thermalFpsCap(1, baseFps))
+        assertEquals(20, AdaptivePolicy.thermalFpsCap(2, baseFps))
+        assertEquals(15, AdaptivePolicy.thermalFpsCap(3, baseFps))
+        assertEquals(12, AdaptivePolicy.thermalFpsCap(5, baseFps))
+    }
+
+    @Test fun fps_cap_never_exceeds_base() {
+        // A saver-style base of 20 must not be raised by the "cool" branch.
+        assertEquals(20, AdaptivePolicy.thermalFpsCap(0, 20))
+        assertEquals(15, AdaptivePolicy.thermalFpsCap(3, 20))
+    }
+
+    // ── AIMD link factor ─────────────────────────────────────────────────────────────────────────
+
+    @Test fun link_backs_off_on_congestion() {
+        val next = AdaptivePolicy.nextLinkFactor(1.0f, AdaptivePolicy.DROP_CONGESTION_THRESHOLD)
+        assertEquals(0.8f, next, 1e-4f)
+    }
+
+    @Test fun link_recovers_gently_when_clean() {
+        val next = AdaptivePolicy.nextLinkFactor(0.8f, 0)
+        assertEquals(0.85f, next, 1e-4f)
+    }
+
+    @Test fun link_never_below_floor_or_above_ceiling() {
+        var f = 1.0f
+        repeat(50) { f = AdaptivePolicy.nextLinkFactor(f, 100) }   // hammer congestion
+        assertEquals(AdaptivePolicy.LINK_MIN, f, 1e-4f)
+        repeat(200) { f = AdaptivePolicy.nextLinkFactor(f, 0) }    // long clean spell
+        assertEquals(AdaptivePolicy.LINK_MAX, f, 1e-4f)
+    }
+
+    @Test fun a_few_drops_below_threshold_are_not_congestion() {
+        val next = AdaptivePolicy.nextLinkFactor(1.0f, AdaptivePolicy.DROP_CONGESTION_THRESHOLD - 1)
+        assertEquals(1.0f, next, 1e-4f) // clean tick → stays at ceiling
+    }
+
+    // ── decide() combines the two ────────────────────────────────────────────────────────────────
+
+    @Test fun cool_and_clean_yields_full_quality() {
+        val d = AdaptivePolicy.decide(base, baseFps, thermalStatus = 0, prevLinkFactor = 1.0f, dropsThisTick = 0)
+        assertEquals(base, d.bitrate)
+        assertEquals(30, d.fps)
+        assertEquals(1.0f, d.linkFactor, 0f)
+    }
+
+    @Test fun hot_reduces_both_bitrate_and_fps() {
+        val d = AdaptivePolicy.decide(base, baseFps, thermalStatus = 3, prevLinkFactor = 1.0f, dropsThisTick = 0)
+        assertEquals((base * 0.6f).toInt(), d.bitrate)   // severe → 0.6
+        assertEquals(15, d.fps)
+    }
+
+    @Test fun the_more_aggressive_pressure_wins_on_bitrate() {
+        // Moderate thermal (0.8) but a badly congested link driven down to the floor (0.4) → link wins.
+        val d = AdaptivePolicy.decide(base, baseFps, thermalStatus = 2, prevLinkFactor = 0.5f, dropsThisTick = 100)
+        // link steps 0.5 → 0.4; min(0.8, 0.4) = 0.4
+        assertEquals(0.4f, d.linkFactor, 1e-4f)
+        assertEquals((base * 0.4f).toInt(), d.bitrate)
+        assertEquals(20, d.fps)   // fps follows thermal (moderate), not link
+    }
+
+    @Test fun bitrate_never_drops_below_the_floor() {
+        val lowBase = 1_000_000
+        // Drive link and thermal both hard; result would be 0.4 * 0.5 semantics, but factor is a min
+        // not a product, so worst factor is 0.4 → 400k, floored to MIN_BITRATE.
+        val d = AdaptivePolicy.decide(lowBase, baseFps, thermalStatus = 6, prevLinkFactor = AdaptivePolicy.LINK_MIN, dropsThisTick = 100)
+        assertTrue("expected >= MIN_BITRATE", d.bitrate >= AdaptivePolicy.MIN_BITRATE)
+    }
+
+    @Test fun floor_is_capped_by_base_when_base_is_tiny() {
+        // If the user's target is somehow below MIN_BITRATE, we must not raise it above the target.
+        val tinyBase = 400_000
+        val d = AdaptivePolicy.decide(tinyBase, baseFps, thermalStatus = 6, prevLinkFactor = AdaptivePolicy.LINK_MIN, dropsThisTick = 100)
+        assertTrue("must never exceed target", d.bitrate <= tinyBase)
+    }
+}

--- a/docs/06-OPTIMIZATION-IDEAS.md
+++ b/docs/06-OPTIMIZATION-IDEAS.md
@@ -1,0 +1,265 @@
+# OpenCfMoto — Optimization & Android Auto Behaviour Ideas
+
+Research notes proposing concrete improvements to app performance, battery/heat, and Android Auto
+(AA) runtime behaviour. Written from a full read of the codebase (video pipeline, AA receiver,
+compositor, handlebar-button bridge, foreground service). **No code has been changed** — this is a
+proposal for discussion/prioritisation.
+
+Read alongside:
+- `04-APP-KNOWLEDGE-BASE.md` — architecture & protocol
+- `05-DEBUG-KNOWLEDGE.md` — runtime flow & the resolved black-screen bugs
+
+---
+
+## The video/AA path today (baseline for these ideas)
+
+```
+Google AA ──H.264──▶ VideoDecoder ──▶ SurfaceTexture ──▶ AaCompositor (GL letterbox)
+   (loopback :5288)     (decode)         (texture)          │ throttled to PowerMode fps
+                                                            ▼
+                                              VideoPipeline encoder (H.264 800x384-ish)
+                                                            │
+                                                            ▼
+                                                 frameQueue (LinkedBlockingDeque, cap 8)
+                                                            │  bike pulls 1 per REQ_RV_DATA_NEXT(114)
+                                                            ▼
+                                              EasyConnProber :10920 ──▶ dash
+```
+
+Key tunables already in place: `PowerMode` fps cap (compositor), `VideoQuality` bitrate multiplier,
+`KEY_REPEAT_PREVIOUS_FRAME_AFTER = 100 ms` (encoder), compositor `IDLE_REDRAW_MS = 2000`,
+`frameQueue` capacity 8, double-tap / long-press timing prefs.
+
+References: [VideoPipeline.kt](../app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt),
+[AaCompositor.kt](../app/src/main/java/dev/zanderp/opencfmoto/AaCompositor.kt),
+[VideoPrefs.kt](../app/src/main/java/dev/zanderp/opencfmoto/VideoPrefs.kt),
+[MediaButtonBridge.kt](../app/src/main/java/dev/zanderp/opencfmoto/MediaButtonBridge.kt).
+
+---
+
+## Idea 1 — Thermal-adaptive frame rate & bitrate (auto Power mode)
+
+> **✅ Implemented (v1.0.10).** Shipped as `PowerMode.AUTO` (now the default). Thermal status is polled
+> each watchdog tick and mapped to a bitrate factor + fps cap by `AdaptivePolicy`; applied live via
+> `VideoPipeline.setEncoderBitrate` / `setFrameCap`. See `AdaptiveVideoController.kt`.
+
+**Problem.** Heat/battery is the headline limitation, called out repeatedly in the README ("this app
+runs a live video transcoder, so it always draws power and warms the phone"). Today the mitigation is
+a *manual* `PowerMode` choice (Smooth 30 / Balanced 24 / Saver 20 fps) that the rider sets once and
+forgets. On a long summer ride the phone can thermally throttle — at which point encode/Wi-Fi slow
+down and the dash stutters — and the app never reacts.
+
+**Evidence.**
+- `PowerMode` is a static user pick, applied once via `AaCompositor.setFrameCap()`
+  ([VideoPrefs.kt:39](../app/src/main/java/dev/zanderp/opencfmoto/VideoPrefs.kt#L39),
+  [VideoPipeline.kt:184](../app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt#L184)).
+- Nothing reads Android's thermal signals anywhere in the tree.
+
+**Proposal.** Add an optional "Auto" power mode that listens to
+`PowerManager.addThermalStatusListener()` (API 29+, already `minSdk`) and/or polls
+`getThermalHeadroom()`, and steps the compositor fps cap (and optionally the encoder bitrate) down as
+the device heats:
+
+| Thermal status | fps cap | bitrate |
+|---|---|---|
+| NONE / LIGHT | user's chosen cap | 100% |
+| MODERATE | 20 | 80% |
+| SEVERE+ | 15 | 60% |
+
+`AaCompositor.setFrameCap()` already supports live changes; bitrate needs
+`MediaCodec.setParameters(PARAMETER_KEY_VIDEO_BITRATE)` (no re-create). Recovery is symmetric as the
+device cools.
+
+**Impact.** Directly attacks the #1 user-visible limitation. Keeps the dash *smooth-at-a-lower-rate*
+instead of stuttering when hot, and extends how long a phone can project before it's uncomfortable.
+**Effort:** small–medium. **Risk:** low (falls back to current static behaviour; gated behind a new
+"Auto" enum value so existing choices are untouched).
+
+---
+
+## Idea 2 — Adaptive bitrate from link-health feedback
+
+> **✅ Implemented (v1.0.10).** Under `PowerMode.AUTO`, `AdaptivePolicy` runs an AIMD loop on the
+> `VideoPipeline` dropped-frame counter (queue-full events) each watchdog tick: multiplicative
+> back-off on congestion, additive recovery when clean, floored at 600 kbps. The more aggressive of
+> the thermal/link factors wins. See `AdaptiveVideoController.kt` + `AdaptivePolicyTest.kt`.
+
+**Problem.** Bitrate is fixed for a session (`profile.videoBitrate × VideoQuality.multiplier`). The
+README admits "in poor Wi-Fi you may hit the occasional hiccup and need a Stop → Connect." The bike
+↔ phone Wi-Fi degrades with distance/obstruction, but the encoder keeps trying to push the same
+2.5 Mbps, causing frame backlog, drops, and eventually the 9 s media-socket timeout → full drop.
+
+**Evidence.**
+- Bitrate chosen once at encoder create; never revised
+  ([VideoPipeline.kt:118](../app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt#L118)).
+- We already have two cheap link-health signals we don't use for control:
+  - `frameQueue` drop-oldest events (encoder outrunning the bike pull rate = downstream congestion)
+    ([VideoPipeline.kt:285](../app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt#L285)).
+  - `EasyConnProber.msSinceLastFrame()` / pull cadence on `REQ_RV_DATA_NEXT`
+    ([EasyConnProber.kt:170](../app/src/main/java/dev/zanderp/opencfmoto/EasyConnProber.kt#L170),
+    [:442](../app/src/main/java/dev/zanderp/opencfmoto/EasyConnProber.kt#L442)).
+
+**Proposal.** A lightweight controller (in the existing watchdog tick, every 5 s) that watches
+queue-drop rate and pull cadence and nudges the encoder bitrate via
+`setParameters(PARAMETER_KEY_VIDEO_BITRATE)`:
+- Sustained queue drops or pull cadence falling below the fps cap → step bitrate **down** (e.g.
+  −20%, floor ~800 kbps) and request a keyframe.
+- Clean streaming for N seconds → step **up** toward the configured target (AIMD, like TCP).
+
+This is a control loop over signals the app already computes — no new protocol, no re-create of the
+codec.
+
+**Impact.** Fewer full drops in marginal Wi-Fi (further from the bike, urban interference), which is
+the most common "it hiccuped" complaint. Graceful degradation (softer picture) instead of a hard
+disconnect. **Effort:** medium. **Risk:** medium — needs bike-test tuning of thresholds; keep it
+behind the existing Auto-recovery setting and log every bitrate change so sessions stay diagnosable.
+
+---
+
+## Idea 3 — Cut glass-to-glass latency (video + touch round-trip)
+
+**Problem.** The pipeline has several buffering stages, and the bike **pulls** frames one at a time.
+The `frameQueue` holds up to 8 encoded access units and, when full, drops the *oldest* while keeping
+the newest 8 — so a bike that pulls slightly slower than the encoder produces can be handed a frame
+up to ~8 frames (≈330 ms at 24 fps) stale. That latency is invisible for steady map panning but hurts
+the **dash-touch → AA → re-encode → dash** round trip (pinch/scroll feel) and turn-prompt timeliness.
+
+**Evidence.**
+- `frameQueue = LinkedBlockingDeque(8)`; drop-oldest-keep-newest on overflow
+  ([VideoPipeline.kt:66](../app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt#L66),
+  [:285](../app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt#L285)).
+- Touch travels dash → PXC cmdType 32 → compositor inverse-map → AAP INPUT → Gearhead, then the
+  visual reply travels the whole video path back
+  ([AaInput.kt](../app/src/main/java/dev/zanderp/opencfmoto/aa/AaInput.kt),
+  `05-DEBUG-KNOWLEDGE.md` §2e).
+
+**Proposal (measure first, then tune).**
+1. Reduce `frameQueue` capacity to **2–3**. With drop-oldest already in place this bounds staleness
+   to ~1–2 frames while still absorbing pull jitter. (`KEY_LATENCY = 1` is already set, so the
+   encoder side is already low-latency —
+   [VideoPipeline.kt:131](../app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt#L131).)
+2. Add a one-line "age of served frame" / queue-depth counter to the log so latency is measurable on
+   a real bike before/after.
+3. Optionally prioritise a fresh keyframe after a touch gesture so scroll/zoom snaps.
+
+**Impact.** Snappier touch on the CFDL26 touch dashes and slightly fresher navigation, plus a small
+memory win. **Effort:** small (capacity + logging) / medium (touch-triggered sync). **Risk:** low —
+smaller queue could in theory increase `no frame ready` under bursty pulls; the added logging tells
+us immediately, and the value is a one-line revert.
+
+---
+
+## Idea 4 — Instant handlebar single-press when no double-tap is mapped
+
+**Problem.** Every single handlebar press is delayed by the double-tap window
+(`ButtonTimingPrefs.doubleTapMs`, 200–450 ms) because the detector must wait to see whether a second
+tap arrives. On a non-touch dash (450SR etc.) where the buttons are the *only* way to drive AA, that
+delay is felt on **every** navigation click — it makes the whole UI feel laggy.
+
+**Evidence.**
+- `detectDoubleTap()` always schedules the single press for `doubleTapMs` later unless a coalesced
+  double is detected
+  ([MediaButtonBridge.kt:375](../app/src/main/java/dev/zanderp/opencfmoto/MediaButtonBridge.kt#L375)).
+- The double-tap variant of a gesture is frequently mapped to `NONE` (do-nothing) or left default —
+  the mapping is fully user-configurable
+  ([ButtonMap.kt](../app/src/main/java/dev/zanderp/opencfmoto/ButtonMap.kt),
+  [ButtonMappingActivity.kt](../app/src/main/java/dev/zanderp/opencfmoto/ButtonMappingActivity.kt)).
+
+**Proposal.** Before arming the deferred single, check whether the *double* gesture actually resolves
+to a real action (`ButtonMap.get(...) != NONE`). If it doesn't, **fire the single immediately** — no
+window to wait for, because there's nothing to disambiguate against. Keep the current deferred path
+only when a double-tap action is genuinely mapped. (The coalesced-volume `forceDouble` fast path is
+unaffected.)
+
+**Impact.** Instant, native-feeling button response for the common case, especially on the non-touch
+bikes that depend on buttons entirely — arguably the single biggest *perceived* responsiveness win
+for those riders. **Effort:** small. **Risk:** low; purely a latency optimisation of existing logic,
+and the safe (deferred) path stays for anyone who maps a double action.
+
+---
+
+## Idea 5 — Idle-aware encoder to cut static-screen heat further
+
+> **✅ Implemented (v1.0.10).** The encoder's `KEY_REPEAT_PREVIOUS_FRAME_AFTER` floor was raised from
+> 100 ms (≈10 fps) to `IDLE_ENCODER_REPEAT_US = 900 ms` (≈1 fps), so a static map is no longer
+> re-encoded ~10× more than needed. `AaCompositor`'s ~2 s idle redraw remains the primary keep-alive;
+> the encoder repeat is now just a backstop under the bike's ~9 s timeout. Both stay well within the
+> timeout. Delivered as a constant change (the repeat interval is configure-time, not live-settable).
+
+**Problem.** When the map is static (stopped at lights, straight highway with no re-draw), the
+compositor already backs off to a ~2 s idle redraw — a deliberate battery win over the old 15 fps
+floor. But the **encoder** is still told to repeat the previous frame every 100 ms
+(`KEY_REPEAT_PREVIOUS_FRAME_AFTER = 100_000`), so it keeps emitting ~10 fps of (near-identical)
+output that gets encoded, queued, and Wi-Fi-transmitted even when nothing is moving. The two idle
+strategies aren't coordinated.
+
+**Evidence.**
+- Compositor idle redraw: `IDLE_REDRAW_MS = 2000`
+  ([AaCompositor.kt:100](../app/src/main/java/dev/zanderp/opencfmoto/AaCompositor.kt#L100)).
+- Encoder repeat floor: `KEY_REPEAT_PREVIOUS_FRAME_AFTER = 100_000L` → ≥10 fps even when static
+  ([VideoPipeline.kt:125](../app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt#L125)).
+- The bike only needs a frame roughly every ~9 s (`socketTimeoutPeriodWifi`) to hold the link
+  (`05-DEBUG-KNOWLEDGE.md` §2f, AaCompositor comment at :96).
+
+**Proposal.** Coordinate the two: when the compositor has been in idle-redraw for a while (no live AA
+frames), raise the encoder's repeat interval toward the compositor's idle cadence via
+`setParameters()` (or simply rely on the compositor's own ~2 s redraws driving the surface and lift
+the 100 ms floor once steady). The safety keyframe/`onBikeDataStart()` logic is unchanged, and the
+9 s timeout is respected with wide margin. On live motion, snap back to the normal cadence.
+
+**Impact.** Meaningful heat/battery reduction during the large fraction of a ride where the map isn't
+moving, on top of the existing compositor win. Complements Idea 1 (thermal) and Idea 2 (bitrate).
+**Effort:** medium. **Risk:** medium — must be careful not to reintroduce the 9 s media-socket
+timeout drop; requires a bike test confirming the link survives long static stretches. Log the idle
+transitions so a regression is obvious.
+
+---
+
+## Appendix — quick wins (lower effort, worth batching)
+
+- **Enable R8 for release.** `isMinifyEnabled = false` in
+  [app/build.gradle.kts:25](../app/build.gradle.kts#L25). Turning on minify + `shrinkResources`
+  (with keep rules for protobuf/Conscrypt/reflection paths) shrinks the sideloaded APK and can
+  slightly improve startup/runtime. Needs a keep-rule pass because the app uses reflection
+  (`AaSelfMode`) and protobuf — test thoroughly before release. *Effort: small; Risk: medium (keep
+  rules).* 
+- **Pre-warm the encoder to cut connect time.** The AA encoder is created lazily at
+  `REQ_CONFIG_CAPTURE`; for a *recognized* bike the canvas size is already known from the profile, so
+  the encoder could be created a beat earlier to shorten the black-to-map gap on connect.
+- **Surface link quality in the UI.** Even before adaptive bitrate (Idea 2), showing the pull
+  cadence / dropped-frame count in the Dash view or Logs helps riders self-diagnose "why is it
+  hiccuping" and gives us the telemetry to tune Ideas 2/3.
+- **Single "Auto" umbrella.** Ideas 1–2 could ship as one rider-facing "Auto (adapts to heat &
+  signal)" power option that internally drives both the thermal fps step-down and the bitrate loop —
+  fewer knobs, better defaults.
+
+---
+
+## Suggested priority
+
+| # | Idea | Impact | Effort | Risk | Notes |
+|---|---|---|---|---|---|
+| 1 | Thermal-adaptive fps/bitrate | High | Small–Med | Low | ✅ Done (v1.0.10) — `PowerMode.AUTO` |
+| 2 | Adaptive bitrate (link) | High | Medium | Medium | ✅ Done (v1.0.10) — needs bike-test tuning |
+| 5 | Idle encoder throttle | Medium (battery) | Medium | Medium | ✅ Done (v1.0.10) — watch 9 s timeout on-bike |
+| 4 | Instant single-press | High (non-touch bikes) | Small | Low | Best effort:impact ratio |
+| 3 | Lower latency (queue + touch) | Medium | Small–Med | Low | Measure first |
+
+Ideas 1, 2 and 5 shipped together (v1.0.10) — they share plumbing: live `MediaCodec.setParameters` on
+the encoder (`VideoPipeline.setEncoderBitrate` / `setFrameCap`) driven from the existing
+`AndroidAutoService` watchdog tick, with the decision math isolated in the pure, unit-tested
+`AdaptivePolicy`. Ideas 3 and 4 remain — independent, low-risk latency wins.
+
+### On-bike verification checklist (for the next real ride)
+
+The adaptation math is unit-tested, but the thresholds want a hardware pass. Watch the shared log for:
+- `[adaptive] thermal=… drops/tick=… link=… → NNNNkbps` — confirms AUTO is live and reacting.
+- On a long **static** stretch, the bike stays connected (no `media closed / bike closed`) with the
+  raised idle repeat — the key idea-5 safety check against the ~9 s media-socket timeout.
+- In **marginal Wi-Fi** (ride away from the bike), bitrate steps down and recovers rather than the
+  projection dropping. Tune `AdaptivePolicy.DROP_CONGESTION_THRESHOLD` / `LINK_*` if it's too eager or
+  too slow.
+- When the phone gets **hot**, fps/bitrate drop (thermal branch). If it never triggers, the device may
+  report thermal status conservatively — consider `getThermalHeadroom()` (API 30) as a finer signal.
+</content>
+</invoke>

--- a/docs/07-IDEAS-AND-ISSUES.md
+++ b/docs/07-IDEAS-AND-ISSUES.md
@@ -1,0 +1,191 @@
+# OpenCfMoto — Ideas & Possible Issues (round 2)
+
+A second research pass, digging into areas the first round (`06-OPTIMIZATION-IDEAS.md`) didn't touch:
+the **connection/PXC layer**, **Wi-Fi handling**, **audio/mic**, **sensors**, **BLE**, and overall
+**code health** — plus some deliberately bold new directions. Grounded in a full read of
+`EasyConnProber`, `AaMicrophone`, `ServiceDiscoveryResponse`, `AapControl`, `BikeWifi`, and friends.
+
+**Nothing here is implemented** — it's a menu to prioritise. Each item cites the code it's about and
+rates rough impact / effort / risk. Ideas 1, 2, 5 from doc 06 already shipped (v1.0.10); doc 06's
+ideas 3 (latency) and 4 (instant single-press) are still open and complement several items below.
+
+---
+
+## Part A — Concrete issues & quick improvements
+
+### A1 ★ No Wi-Fi lock → avoidable stream jitter, worst exactly when riding
+
+> **✅ Implemented (v1.0.10).** `AndroidAutoService` now holds two Wi-Fi locks for the streaming
+> session — **`WIFI_MODE_FULL_HIGH_PERF`** (keeps Wi-Fi out of power-save regardless of screen state,
+> the screen-off workhorse) **and `WIFI_MODE_FULL_LOW_LATENCY`** (extra latency reduction while
+> foreground + screen-on). Acquired with the wake lock (`reacquireLocks`), released on park/stop.
+> Note: `LOW_LATENCY` alone would **not** cover screen-off riding — it's active only foreground +
+> screen-on ([AOSP Wi-Fi low-latency docs][aosp-ll]) — which is exactly why both are held.
+
+[aosp-ll]: https://source.android.com/docs/core/connect/wifi-low-latency
+
+**The gap.** The app streams video over the bike's Wi-Fi and explicitly tells riders to **turn the
+phone screen off** while riding — but it never acquires a `WifiManager.WifiLock`. With the screen off,
+Android's Wi-Fi power-save aggressively parks the radio between beacons, adding latency and jitter and
+sometimes throttling throughput. That's precisely the condition the whole app runs in.
+
+**Evidence.** A repo-wide search finds only a BLE scan mode — **no `WifiLock` / `WIFI_MODE_*`
+anywhere.** `BikeWifi` binds the process to the bike network but takes no lock; `EasyConnProber` takes
+a `MulticastLock` only ([EasyConnProber.kt:570](../app/src/main/java/dev/zanderp/opencfmoto/EasyConnProber.kt#L570)).
+
+**Proposal.** Hold a `WifiLock` with **`WIFI_MODE_FULL_LOW_LATENCY`** (added API 29 — the app's
+`minSdk`) for the duration of a streaming session, acquired next to the existing partial wake lock in
+`AndroidAutoService`, and released on park/stop. Low-latency mode disables power-save *and* asks the
+firmware to prioritise latency while the app is foregrounded/holding the lock.
+
+**Impact:** smoother stream + snappier touch, especially screen-off — the single highest-value, lowest-
+risk item here. **Effort:** small. **Risk:** low (slightly more Wi-Fi radio power; already gated to a
+live session, and it *reduces* re-transmit/stall overhead). Pairs naturally with doc 06's adaptive
+tuning and latency ideas.
+
+### A2 — "Hacked by Coletz :P" placeholder renders to the dash
+
+The own-content Presentation path draws literal `"Hacked by Coletz :P"` + a `"frame tick N"` ticker
+onto the bike screen ([VideoPipeline.kt:241](../app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt#L241)).
+It's leftover from the pre-AA proof-of-concept and only shows when neither AA nor mirror is the source,
+but it *is* shipped code that can appear on a motorcycle dash. Replace with a neutral OpenCfMoto
+standby card (logo + connection state), or delete the path if own-content mode is dead.
+**Effort:** trivial. **Risk:** none. (Polish, but it's the kind of thing that ends up in a screenshot.)
+
+### A3 — Thin automated test coverage on the fragile, pure code
+
+Only `AdaptivePolicyTest` + the example test exist. Several **pure, unit-testable** pieces are exactly
+the ones with a history of subtle breakage, and would be cheap to lock down:
+- `PxcFrame` framing + the `magic = cmdType XOR totalLength` check — the docs note the bike **drops the
+  connection** on a bad magic ([04-APP-KNOWLEDGE-BASE.md §4.1]).
+- The H.264 `SpsParser` in `VideoDecoder` — dimension parsing sits on the black-screen fault line.
+- `AaCompositor.mapCanvasToSource()` letterbox inverse — touch accuracy across FIT/FILL/STRETCH
+  ([AaCompositor.kt:231](../app/src/main/java/dev/zanderp/opencfmoto/AaCompositor.kt#L231)).
+- The `MediaButtonBridge` double-tap / long-press state machine (recently reworked in 1.0.8).
+
+**Impact:** regression insurance on the code most likely to regress. **Effort:** small–medium.
+**Risk:** none.
+
+### A4 — Media data socket blocks up to 1.5 s per pull
+
+On each `REQ_RV_DATA_NEXT(114)` the media thread calls `pollFrame(1500)`, blocking up to 1.5 s
+([EasyConnProber.kt:443](../app/src/main/java/dev/zanderp/opencfmoto/EasyConnProber.kt#L443)). Now that
+idle throttle (doc 06 idea 5) drops static output to ~1 fps, a still screen can make the bike wait
+~0.9–1.5 s for a frame. It still works (the idle repeat delivers within the window), but it's worth a
+quick on-bike check that the raised idle-repeat and this timeout stay comfortably inside the ~9 s
+media-socket timeout, and logging `no frame ready` occurrences. **Effort:** small (measure first).
+**Risk:** low — flagged so idea-5's on-bike verification also covers it.
+
+### A5 — Port-conflict error could self-heal
+
+When the official CFMoto/EasyConnect app holds ports 10920–10922, the prober fails fast with a good
+message ([EasyConnProber.kt:125](../app/src/main/java/dev/zanderp/opencfmoto/EasyConnProber.kt#L125)).
+Nice, but it dead-ends until the rider manually force-stops that app. Since the app already knows how
+to deep-link to App settings (README troubleshooting), the ERROR state could offer a one-tap
+"force-stop the CFMoto app" action and **auto-retry the bind** once the ports free — turning a manual
+recovery into one tap. **Effort:** small–medium. **Risk:** low.
+
+### A6 — Hardcoded BLE pairing secrets (dormant, but a footgun if promoted)
+
+`BleSecrets` ships AES-256 pairing keys with a `TODO: replace with a runtime loader`
+([BleSecrets.kt:7](../app/src/main/java/dev/zanderp/opencfmoto/BleSecrets.kt#L7)). The BLE wake-up path
+is dormant, so it's harmless today — but if BLE wake is ever promoted, hardcoded keys mean it only
+works for the bikes those keys match, and bakes secrets into an open repo. If/when it's revived, load
+keys at runtime (e.g. from the official app's store) instead. **Effort:** medium. **Risk:** n/a while
+dormant — noted so it isn't forgotten.
+
+### A7 — R8 / resource shrinking off for release
+
+Carried over from doc 06's appendix: `isMinifyEnabled = false`
+([app/build.gradle.kts](../app/build.gradle.kts)). Enabling R8 + `shrinkResources` shrinks the
+sideloaded APK and strips debug logging in release, but needs keep-rules for protobuf, Conscrypt, and
+the reflective `AaSelfMode`. **Effort:** small–medium (keep rules). **Risk:** medium — test the full
+connect flow after enabling.
+
+---
+
+## Part B — Bold new directions
+
+### B1 ★★ Turn the letterbox bars into a rider HUD (telemetry overlay)
+
+**The insight.** Android Auto renders at a fixed 16:9-ish resolution; the bike dash is a different
+shape; so the compositor **letterboxes** AA into the canvas, leaving black bars (e.g. a portrait
+1000 MT-X, or any FIT-mode dash). Those bars are wasted pixels on a screen the rider stares at.
+
+**The idea.** The GL `AaCompositor` already composites the AA texture into a viewport and *already*
+supports a second render target (the in-app preview). Extend it to draw an **OpenCfMoto telemetry
+strip** into the otherwise-black margin: GPS speed, trip distance/time, a clock, phone battery + a hot-
+phone warning, and a glanceable next-turn. Every value already exists — `TripRecorder` has live
+speed/distance, and the adaptive controller now knows thermal state. This is a genuinely novel,
+motorcycle-specific dash that *no* stock Android Auto head unit offers, built almost entirely on
+plumbing that's already there.
+
+**Impact:** flagship differentiator; makes the mismatched-aspect dashes (the majority) strictly better
+instead of "letterboxed." **Effort:** medium (GL text/quad rendering + a data feed into the
+compositor). **Risk:** low–medium (must not steal frame budget from the map; render the strip only when
+values change, reusing idea-5's idle logic).
+
+### B2 ★★ Crash detection + SOS
+
+A motorcycle safety feature with **zero Android Auto dependency**. The phone already has the sensors
+and (with trip logging) location. Watch the accelerometer/GPS for a crash signature — sharp
+deceleration + orientation flip + a sustained stop — then show a **cancelable countdown** on the dash /
+phone; if the rider doesn't cancel, surface an SOS with the last known GPS coordinates (share-sheet or
+a pre-set emergency contact — the actual send stays rider-initiated). Fits the existing ride-logging
+theme and the "we're a riding app, not just a projector" identity.
+
+**Impact:** high — a headline, trust-building feature riders genuinely value. **Effort:** medium
+(sensor fusion + a tunable detector + UI). **Risk:** medium — false positives must be easy to dismiss;
+be explicit it's best-effort and never a substitute for a real crash beacon. Keep it opt-in.
+
+### B3 ★ Feed the phone's GPS as an AA head-unit sensor
+
+The AAP **SENSOR** channel is rich — `Sensors.java` carries `SensorBatch` with location, speed,
+odometer, RPM, fuel, etc. — but today the head unit only advertises `DRIVING_STATUS` and `NIGHT`, and
+`DRIVING_STATUS` is sent **once** as `UNRESTRICTED`
+([AapControl.kt:297](../app/src/main/java/dev/zanderp/opencfmoto/aa/AapControl.kt#L297),
+[ServiceDiscoveryResponse.kt:44](../app/src/main/java/dev/zanderp/opencfmoto/aa/ServiceDiscoveryResponse.kt#L44)).
+Advertising and feeding a **LOCATION/speed sensor** from the phone's fused location could steady Maps'
+positioning (tunnels, urban canyons) and unlock an accurate in-map speed readout. Scoped and protocol-
+careful, but the proto support is already generated. **Impact:** medium. **Effort:** medium. **Risk:**
+medium (keep `DRIVING_STATUS` UNRESTRICTED — deliberately chosen so the dash stays fully interactive).
+
+### B4 — Localization (reach CFMoto's actual markets)
+
+All UI strings are inline English in the activities (`SetupActivity`, etc.) — no `strings.xml`
+extraction. CFMoto's biggest rider bases are non-English (EU, China, LATAM). Extracting strings and
+adding even two or three translations widens the audience far more than most features, for modest,
+mechanical effort. **Impact:** high (reach). **Effort:** medium (extraction is the bulk). **Risk:** low.
+
+### B5 — "It just knows" context automation
+
+Small orchestrations that make the app feel smart, composing features that already exist: auto-enable
+handlebar-button mode when a **non-touch** profile connects; auto-apply the bike's saved map theme;
+optionally auto-launch a saved "home" navigation on connect (the `NavLauncher` + `SavedPlaces` +
+per-bike settings are all there). Each is a few lines of glue in the connect path. **Impact:** medium
+(polish/delight). **Effort:** small. **Risk:** low (all opt-in/toggleable).
+
+---
+
+## Suggested priority
+
+| # | Item | Type | Impact | Effort | Risk |
+|---|---|---|---|---|---|
+| A1 | **Wi-Fi high-perf + low-latency lock** ✅ done (v1.0.10) | Fix/perf | High | Small | Low |
+| B1 | **Telemetry HUD in the letterbox bars** | Feature | High (flagship) | Medium | Low–Med |
+| A2 | Remove "Hacked by Coletz" placeholder | Cleanup | Low | Trivial | None |
+| B2 | Crash detection + SOS | Feature | High | Medium | Medium |
+| A3 | Unit-test the fragile pure code | Health | Med | Small–Med | None |
+| B4 | Localization | Reach | High | Medium | Low |
+| A5 | Self-healing port-conflict recovery | UX | Med | Small–Med | Low |
+| B3 | GPS-as-AA-sensor | Feature | Med | Medium | Medium |
+| B5 | Context automation on connect | Polish | Med | Small | Low |
+| A7 | R8 / resource shrink | Build | Low–Med | Small–Med | Med |
+| A4 | Cap/measure pollFrame block | Perf | Low | Small | Low |
+| A6 | BLE runtime key loader (if revived) | Security | — | Medium | n/a |
+
+**If I were picking two to do next:** **A1 (Wi-Fi low-latency lock)** — the best effort-to-impact ratio
+in the whole list, and it reinforces the adaptive work just shipped — and **B1 (telemetry HUD)** as the
+flagship feature, since the GL and data plumbing it needs already exist. Doc 06's **idea 4 (instant
+single-press)** remains the cheapest UX win for non-touch bikes and would slot in alongside A1.
+</content>


### PR DESCRIPTION
Two related power/reliability improvements to the Android Auto streaming path, plus roadmap docs. Rebased on latest `zanderp/main` (1.0.9) and bumped to **1.0.10 / versionCode 11**.

## 1. Adaptive video tuning — `PowerMode.AUTO` (ideas 1, 2, 5 from `docs/06`)

A self-tuning power mode that keeps the dash smooth and connected instead of stuttering when the phone heats up or the bike Wi-Fi link degrades. Shares one control path: **live `MediaCodec.setParameters` on the running encoder, driven from the existing `AndroidAutoService` watchdog tick**.

- **Thermal-adaptive:** maps `PowerManager.currentThermalStatus` → bitrate factor + fps cap (steps down at MODERATE/SEVERE/CRITICAL, recovers as it cools).
- **Link-adaptive:** AIMD loop on a new `VideoPipeline` dropped-frame counter (queue-full = congestion) — back off multiplicatively, recover additively, floored at 600 kbps. The more aggressive of thermal/link wins.
- **Idle encoder:** `KEY_REPEAT_PREVIOUS_FRAME_AFTER` 100 ms → 900 ms so a static map isn't re-encoded ~10× more than needed (compositor's ~2 s idle redraw stays the keep-alive, well under the bike's ~9 s timeout).
- Decision math isolated in the pure, unit-tested `AdaptivePolicy`. **AUTO is the new default** for fresh installs; existing choices are kept. New **Auto** button in Setup ▸ Battery & power.

## 2. Wi-Fi locks while streaming (A1 from `docs/07`)

The app streams real-time video over the bike Wi-Fi and tells riders to ride **screen-off** — exactly when Android parks the radio and adds latency/jitter. Nothing held a `WifiLock` (only a `MulticastLock`).

- Now holds **`WIFI_MODE_FULL_HIGH_PERF`** (out of power-save regardless of screen — the screen-off workhorse) **+ `WIFI_MODE_FULL_LOW_LATENCY`** (extra latency cut while foreground + screen-on). `LOW_LATENCY` alone is foreground/screen-on only per [AOSP](https://source.android.com/docs/core/connect/wifi-low-latency), which is why both are held.
- Acquired with the wake lock (`reacquireLocks`), released on park/stop. No new permissions.

## Safety / risk

- Fixed power modes (Smooth/Balanced/Saver) **short-circuit the adaptive controller entirely** — unchanged behaviour. AUTO can only reduce to soft-but-working floors (≥600 kbps, ≥12 fps): worst case a softer map, never a black screen or drop.
- Wi-Fi locks are released when parked/stopped so a waiting bike lets the radio idle.

## Testing

- `AdaptivePolicyTest` — **13 unit tests** (thermal mapping, AIMD bounds, floors/ceilings, combined `decide()`). All pass.
- `./gradlew testDebugUnitTest assembleDebug` — **BUILD SUCCESSFUL.**
- ⚠️ **Not yet ridden.** Adaptive thresholds, the idle-repeat vs 9 s timeout, and the real-world Wi-Fi-lock benefit (screen-off) want one on-bike pass — see the verification checklists in `docs/06` and `docs/07`.

## Notes for review

- **AUTO as default** for new installs is a product call — happy to make it opt-in (one-line change in `VideoPrefs.power()`).
- `docs/07-IDEAS-AND-ISSUES.md` is included as roadmap context (a second research pass: connection layer, Wi-Fi, sensors, code health, plus bolder feature ideas). A1 there is the Wi-Fi-lock work in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
