### PR TITLE
1.0.16: rider HUD in the dash letterbox bars + HUD settings screen (B1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "dev.zanderp.opencfmoto"
         minSdk = 29
         targetSdk = 36
-        versionCode = 16
-        versionName = "1.0.15"
+        versionCode = 17
+        versionName = "1.0.16"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,6 +90,9 @@
             android:name=".HudViewActivity"
             android:exported="false"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden" />
+        <activity
+            android:name=".HudSettingsActivity"
+            android:exported="false" />
         <service
             android:name=".ProjectionService"
             android:exported="false"

--- a/app/src/main/java/dev/zanderp/opencfmoto/AaCompositor.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/AaCompositor.kt
@@ -9,6 +9,7 @@ import android.opengl.EGLExt
 import android.opengl.EGLSurface
 import android.opengl.GLES11Ext
 import android.opengl.GLES20
+import android.opengl.GLUtils
 import android.opengl.Matrix
 import android.os.Handler
 import android.os.HandlerThread
@@ -65,6 +66,30 @@ class AaCompositor(private val log: (String) -> Unit) {
     private var uTexMatrix = 0
     private var textureId = 0
     private lateinit var surfaceTexture: SurfaceTexture
+
+    // ── Rider HUD (idea B1): paint telemetry into the FIT letterbox bars ──────────────────────────
+    // A second, plain-2D GL program draws a Canvas-rendered bitmap (speed/trip/clock/battery) into
+    // each detected black bar, on top of the AA frame, in the bike encoder surface only. Bars are
+    // computed from the viewport in FIT mode (none in FILL/STRETCH); the bitmap is only re-rendered
+    // and re-uploaded when a displayed value changes (~1 Hz), so it barely touches the idle throttle.
+    private var hudProgram = 0
+    private var hudAPos = 0
+    private var hudATex = 0
+    private var hudUTex = 0
+    @Volatile private var hudBars: List<BarRect> = emptyList()
+    private val hudTextures = HashMap<Int, Int>()   // bar index → GL texture id
+    private val hudSigs = HashMap<Int, String>()    // bar index → last uploaded content signature
+    // Quad with V flipped (Android bitmaps upload top-row-first, GL samples bottom-up).
+    private val hudQuad: FloatBuffer = ByteBuffer
+        .allocateDirect(4 * 4 * 4).order(ByteOrder.nativeOrder()).asFloatBuffer().apply {
+            put(floatArrayOf(
+                -1f, -1f, 0f, 1f,
+                 1f, -1f, 1f, 1f,
+                -1f,  1f, 0f, 0f,
+                 1f,  1f, 1f, 0f,
+            ))
+            position(0)
+        }
 
     /** Where the AA decoder renders. Valid after [start]. */
     @Volatile var inputSurface: Surface? = null
@@ -270,6 +295,30 @@ class AaCompositor(private val log: (String) -> Unit) {
         }
         vpX = (canvasW - vpW) / 2
         vpY = (canvasH - vpH) / 2
+        computeHudBars()
+    }
+
+    /** Recompute the letterbox bars the HUD paints into, and (re)allocate a GL texture per bar.
+     *  Runs on the GL thread (called from [computeViewport], which is inside a handler post). */
+    private fun computeHudBars() {
+        val bars = HudBars.detect(canvasW, canvasH, vpX, vpY, vpW, vpH, fitMode, HUD_MIN_BAR_PX)
+        // Free any textures we no longer need, allocate any new ones.
+        if (bars.size != hudBars.size) {
+            hudTextures.values.forEach { id -> try { GLES20.glDeleteTextures(1, intArrayOf(id), 0) } catch (_: Exception) {} }
+            hudTextures.clear(); hudSigs.clear()
+            for (i in bars.indices) {
+                val ids = IntArray(1)
+                GLES20.glGenTextures(1, ids, 0)
+                GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, ids[0])
+                GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+                GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+                GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
+                GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+                hudTextures[i] = ids[0]
+            }
+        }
+        hudBars = bars
+        if (bars.isNotEmpty()) log("[COMPOSITOR] HUD bars=${bars.size} (${bars.joinToString { "${it.w}x${it.h}@(${it.x},${it.y})" }})")
     }
 
     /** Set the live-frame cap (frames/sec) from the user's [dev.zanderp.opencfmoto.PowerMode]. */
@@ -324,14 +373,15 @@ class AaCompositor(private val log: (String) -> Unit) {
     private fun drawFrame() {
         if (windowSurface == EGL14.EGL_NO_SURFACE && previewSurface == EGL14.EGL_NO_SURFACE) return
         surfaceTexture.getTransformMatrix(texMatrix)
-        if (windowSurface != EGL14.EGL_NO_SURFACE) renderTo(windowSurface, vpX, vpY, vpW, vpH)
-        if (previewSurface != EGL14.EGL_NO_SURFACE) renderTo(previewSurface, ppX, ppY, ppW, ppH)
+        // The HUD is painted into the bars of the BIKE surface only (not the phone preview).
+        if (windowSurface != EGL14.EGL_NO_SURFACE) renderTo(windowSurface, vpX, vpY, vpW, vpH, drawHud = true)
+        if (previewSurface != EGL14.EGL_NO_SURFACE) renderTo(previewSurface, ppX, ppY, ppW, ppH, drawHud = false)
         lastDrawMs = android.os.SystemClock.uptimeMillis()
         pendingFrame = false
     }
 
     /** Render the latched frame into [target], letterboxed to viewport ([vx],[vy],[vw],[vh]). */
-    private fun renderTo(target: EGLSurface, vx: Int, vy: Int, vw: Int, vh: Int) {
+    private fun renderTo(target: EGLSurface, vx: Int, vy: Int, vw: Int, vh: Int, drawHud: Boolean = false) {
         EGL14.eglMakeCurrent(eglDisplay, target, target, eglContext)
 
         // Black background (the letterbox bars).
@@ -358,14 +408,64 @@ class AaCompositor(private val log: (String) -> Unit) {
         GLES20.glDisableVertexAttribArray(aPosition)
         GLES20.glDisableVertexAttribArray(aTexCoord)
 
+        // Paint the rider HUD into the black bars, over the AA frame (bike surface only). Guarded so a
+        // HUD glitch can never take down the video path.
+        if (drawHud && HudBus.enabled && hudBars.isNotEmpty()) {
+            try { drawHudPanels() } catch (e: Exception) { log("[COMPOSITOR] HUD draw failed: $e") }
+        }
+
         // Monotonic presentation time so repeated (keep-alive) frames aren't dropped as duplicate PTS.
         EGLExt.eglPresentationTimeANDROID(eglDisplay, target, System.nanoTime())
         EGL14.eglSwapBuffers(eglDisplay, target)
     }
 
+    /**
+     * Draw each HUD bar's texture into its bar rect on the current surface. The bitmap is only
+     * re-rendered + re-uploaded when its content signature changes (~1 Hz), so a static screen stays
+     * cheap; the textured-quad draw itself runs every frame. Assumes the AA program's attrib arrays
+     * were already disabled by [renderTo]. Bar rects are top-left; GL viewport is bottom-left, hence
+     * the Y flip.
+     */
+    private fun drawHudPanels() {
+        val bars = hudBars
+        if (bars.isEmpty()) return
+        val cellsPerBar = HudLayout.distribute(
+            HudLayout.cells(HudBus.stats, HudBus.unit, HudBus.clock, HudBus.elements), bars.size,
+        )
+        GLES20.glUseProgram(hudProgram)
+        hudQuad.position(0)
+        GLES20.glVertexAttribPointer(hudAPos, 2, GLES20.GL_FLOAT, false, 16, hudQuad)
+        GLES20.glEnableVertexAttribArray(hudAPos)
+        hudQuad.position(2)
+        GLES20.glVertexAttribPointer(hudATex, 2, GLES20.GL_FLOAT, false, 16, hudQuad)
+        GLES20.glEnableVertexAttribArray(hudATex)
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
+        for ((i, bar) in bars.withIndex()) {
+            val tex = hudTextures[i] ?: continue
+            val cells = cellsPerBar.getOrElse(i) { emptyList() }
+            val sig = HudLayout.signature(cells)
+            if (hudSigs[i] != sig) {
+                val bmp = HudRenderer.render(bar, cells)
+                GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, tex)
+                GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bmp, 0)
+                bmp.recycle()
+                hudSigs[i] = sig
+            }
+            GLES20.glViewport(bar.x, canvasH - (bar.y + bar.h), bar.w, bar.h)
+            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, tex)
+            GLES20.glUniform1i(hudUTex, 0)
+            GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+        }
+        GLES20.glDisableVertexAttribArray(hudAPos)
+        GLES20.glDisableVertexAttribArray(hudATex)
+    }
+
     fun release() {
         handler.removeCallbacks(keepAlive)
         handler.post {
+            // The EGL context teardown below frees all GL objects (incl. HUD textures/program); just
+            // drop our bookkeeping so a reused instance starts clean.
+            hudTextures.clear(); hudSigs.clear(); hudBars = emptyList()
             try { inputSurface?.release() } catch (_: Exception) {}
             try { if (::surfaceTexture.isInitialized) surfaceTexture.release() } catch (_: Exception) {}
             if (eglDisplay != EGL14.EGL_NO_DISPLAY) {
@@ -440,6 +540,28 @@ class AaCompositor(private val log: (String) -> Unit) {
         GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
         GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
         GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+
+        initHudGl()
+    }
+
+    /** Build the plain-2D program used to draw the HUD bitmap into the letterbox bars. */
+    private fun initHudGl() {
+        val vs = """
+            attribute vec4 aPosition;
+            attribute vec2 aTexCoord;
+            varying vec2 vTexCoord;
+            void main() { gl_Position = aPosition; vTexCoord = aTexCoord; }
+        """.trimIndent()
+        val fs = """
+            precision mediump float;
+            varying vec2 vTexCoord;
+            uniform sampler2D uTex;
+            void main() { gl_FragColor = texture2D(uTex, vTexCoord); }
+        """.trimIndent()
+        hudProgram = linkProgram(vs, fs)
+        hudAPos = GLES20.glGetAttribLocation(hudProgram, "aPosition")
+        hudATex = GLES20.glGetAttribLocation(hudProgram, "aTexCoord")
+        hudUTex = GLES20.glGetUniformLocation(hudProgram, "uTex")
     }
 
     private fun linkProgram(vsSrc: String, fsSrc: String): Int {
@@ -469,5 +591,10 @@ class AaCompositor(private val log: (String) -> Unit) {
             throw RuntimeException("shader compile failed: $err")
         }
         return s
+    }
+
+    companion object {
+        /** Minimum bar thickness (px) to bother painting the HUD — below this, text can't be legible. */
+        private const val HUD_MIN_BAR_PX = 56
     }
 }

--- a/app/src/main/java/dev/zanderp/opencfmoto/AndroidAutoService.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/AndroidAutoService.kt
@@ -35,6 +35,7 @@ class AndroidAutoService : Service() {
     private var pipeline: VideoPipeline? = null
     private var receiver: AaReceiver? = null
     private var mediaButtons: MediaButtonBridge? = null
+    private var hudStats: HudStatsProvider? = null
     private var wakeLock: PowerManager.WakeLock? = null
     // Wi-Fi locks that keep the bike link fast for the whole streaming session (see [acquireWifiLocks]).
     // Two are held on purpose: LOW_LATENCY only engages while the app is foreground AND the screen is
@@ -166,6 +167,9 @@ class AndroidAutoService : Service() {
         try { BikeLink.prober?.stop() } catch (_: Exception) {}
         try { mediaButtons?.stop() } catch (_: Exception) {}
         mediaButtons = null
+        try { hudStats?.stop() } catch (_: Exception) {}
+        hudStats = null
+        HudBus.enabled = false
         try { receiver?.stop() } catch (_: Exception) {}
         receiver = null
         AaVideoBridge.pipeline = null
@@ -378,6 +382,11 @@ class AndroidAutoService : Service() {
             }
             // Capture the bike's handlebar buttons (Bluetooth AVRCP) → Android Auto navigation.
             mediaButtons = MediaButtonBridge(applicationContext, LogBus::log).also { it.start() }
+            // Rider HUD (B1): publish the toggle/unit/elements for the compositor and feed it live stats.
+            HudBus.enabled = VideoPrefs.hudEnabled(applicationContext)
+            HudBus.unit = VideoPrefs.speedUnit(applicationContext)
+            HudBus.elements = VideoPrefs.hudElements(applicationContext)
+            hudStats = HudStatsProvider(applicationContext, LogBus::log).also { it.start() }
         } catch (e: Exception) {
             LogBus.log("[AA] receiver start failed: $e")
             stopSelf()
@@ -434,6 +443,9 @@ class AndroidAutoService : Service() {
         try { TripLogger.current?.stopAndSave() } catch (_: Exception) {}
         try { mediaButtons?.stop() } catch (_: Exception) {}
         mediaButtons = null
+        try { hudStats?.stop() } catch (_: Exception) {}
+        hudStats = null
+        HudBus.enabled = false
         try { receiver?.stop() } catch (_: Exception) {}
         receiver = null
         AaVideoBridge.pipeline = null

--- a/app/src/main/java/dev/zanderp/opencfmoto/HudModel.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/HudModel.kt
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Alexandru <https://alexandru.rocks> and the OpenCfMoto contributors.
+// Part of OpenCfMoto. Free software under the GNU AGPL v3 or later; see LICENSE and NOTICE.
+package dev.zanderp.opencfmoto
+
+import java.util.Locale
+
+/**
+ * Pure model + math for the on-dash rider HUD (idea B1). No Android dependencies here, so the
+ * geometry, formatting and layout are all host-unit-testable ([HudModelTest]); the Android glue
+ * (GPS/battery/thermal source, Canvas→GL rendering) lives in [HudStatsProvider] / [HudRenderer] /
+ * [AaCompositor].
+ *
+ * Concept: when the screen fit is FIT, the AA video is letterboxed into the bike canvas, leaving
+ * black bars. Instead of wasting them we paint live ride telemetry there — speed (hero), trip
+ * distance/time, clock, phone battery and a hot-phone warning — without touching the AA image.
+ */
+
+/** Speed/distance unit for the HUD. */
+enum class SpeedUnit(val speedLabel: String) { KMH("km/h"), MPH("mph") }
+
+/** A snapshot of everything the HUD can show. Produced by [HudStatsProvider]; pure data. */
+data class RideStats(
+    val speedKmh: Int = 0,
+    val distanceMeters: Double = 0.0,
+    val movingTimeMs: Long = 0L,
+    val hasFix: Boolean = false,
+    val batteryPct: Int = -1,        // -1 = unknown
+    val charging: Boolean = false,
+    val thermalStatus: Int = 0,      // PowerManager.THERMAL_STATUS_* (0 = none)
+) {
+    /** Phone running warm enough to surface a warning (matches AdaptiveVideoController's throttle point). */
+    val hot: Boolean get() = thermalStatus >= 2   // THERMAL_STATUS_MODERATE
+}
+
+/** Pure formatting for HUD values. Uses [Locale.US] so host tests are deterministic. */
+object HudFormat {
+    fun speed(stats: RideStats, unit: SpeedUnit): String {
+        if (!stats.hasFix) return "--"
+        val v = if (unit == SpeedUnit.MPH) Math.round(stats.speedKmh * 0.621371).toInt() else stats.speedKmh
+        return v.coerceAtLeast(0).toString()
+    }
+
+    fun distance(meters: Double, unit: SpeedUnit): String =
+        if (unit == SpeedUnit.MPH) {
+            val mi = meters / 1609.344
+            if (mi < 10) String.format(Locale.US, "%.1f mi", mi) else "${Math.round(mi)} mi"
+        } else {
+            val km = meters / 1000.0
+            if (km < 10) String.format(Locale.US, "%.1f km", km) else "${Math.round(km)} km"
+        }
+
+    /** m:ss under an hour, h:mm:ss past it. */
+    fun duration(ms: Long): String {
+        val totalSec = (ms / 1000).coerceAtLeast(0)
+        val h = totalSec / 3600
+        val m = (totalSec % 3600) / 60
+        val s = totalSec % 60
+        return if (h > 0) String.format(Locale.US, "%d:%02d:%02d", h, m, s)
+        else String.format(Locale.US, "%d:%02d", m, s)
+    }
+
+    fun battery(pct: Int, charging: Boolean): String {
+        if (pct < 0) return "--"
+        return if (charging) "$pct%+" else "$pct%"
+    }
+}
+
+/** A detected letterbox bar the HUD can paint into (bike-canvas pixels). */
+data class BarRect(val x: Int, val y: Int, val w: Int, val h: Int) {
+    /** Tall-and-narrow bars stack their cells vertically; wide-and-short ones lay out in a row. */
+    val vertical: Boolean get() = h >= w
+    val area: Long get() = w.toLong() * h
+}
+
+object HudBars {
+    /**
+     * The bars FIT letterboxing produces = the canvas minus the centered AA viewport. Returns bars
+     * only in FIT mode (FILL/STRETCH cover the whole canvas, so there are none) and only those at
+     * least [minThickness] px thick, so text is legible. FIT centers exactly one axis, so this yields
+     * either the two side bars or the two top/bottom bars, never both.
+     */
+    fun detect(
+        canvasW: Int, canvasH: Int,
+        vpX: Int, vpY: Int, vpW: Int, vpH: Int,
+        fit: ScreenFit, minThickness: Int,
+    ): List<BarRect> {
+        if (fit != ScreenFit.FIT) return emptyList()
+        if (canvasW <= 0 || canvasH <= 0 || vpW <= 0 || vpH <= 0) return emptyList()
+        val bars = ArrayList<BarRect>(2)
+        val leftW = vpX
+        val rightW = canvasW - (vpX + vpW)
+        val topH = vpY
+        val botH = canvasH - (vpY + vpH)
+        if (leftW >= minThickness) bars.add(BarRect(0, 0, leftW, canvasH))
+        if (rightW >= minThickness) bars.add(BarRect(vpX + vpW, 0, rightW, canvasH))
+        if (topH >= minThickness) bars.add(BarRect(0, 0, canvasW, topH))
+        if (botH >= minThickness) bars.add(BarRect(0, vpY + vpH, canvasW, botH))
+        return bars
+    }
+}
+
+/** One HUD readout: a big [value] with a small [label] under it. */
+data class HudCell(val value: String, val label: String, val big: Boolean = false)
+
+/** A telemetry item the rider can turn on/off in the HUD settings screen. Order = draw order. */
+enum class HudElement(val label: String) {
+    SPEED("Speed"),
+    TRIP("Trip distance"),
+    TIME("Ride time"),
+    CLOCK("Clock"),
+    BATTERY("Phone battery"),
+    TEMP("Overheat warning"),
+    ;
+
+    companion object {
+        val ALL: Set<HudElement> = values().toSet()
+    }
+}
+
+object HudLayout {
+    /**
+     * Ordered cells for a stats snapshot, filtered to the [enabled] elements (rider's choice). Speed
+     * is the emphasized hero; [HudElement.TEMP] only appears when [enabled] and the phone is hot.
+     * Fewer enabled elements → bigger, cleaner readouts, which is how thin/tall bars are kept legible.
+     */
+    fun cells(
+        stats: RideStats,
+        unit: SpeedUnit,
+        clockHHmm: String,
+        enabled: Set<HudElement> = HudElement.ALL,
+    ): List<HudCell> {
+        val list = ArrayList<HudCell>(6)
+        if (HudElement.SPEED in enabled) list.add(HudCell(HudFormat.speed(stats, unit), unit.speedLabel, big = true))
+        if (HudElement.TRIP in enabled) list.add(HudCell(HudFormat.distance(stats.distanceMeters, unit), "trip"))
+        if (HudElement.TIME in enabled) list.add(HudCell(HudFormat.duration(stats.movingTimeMs), "time"))
+        if (HudElement.CLOCK in enabled) list.add(HudCell(clockHHmm, "clock"))
+        if (HudElement.BATTERY in enabled) list.add(HudCell(HudFormat.battery(stats.batteryPct, stats.charging), "phone"))
+        if (HudElement.TEMP in enabled && stats.hot) list.add(HudCell("HOT", "temp"))
+        return list
+    }
+
+    /**
+     * Split cells across [barCount] bars, order-preserving (speed lands in the first bar). One bar
+     * gets everything; two bars split roughly evenly (so the 800MT's two side bars share the load).
+     */
+    fun distribute(cells: List<HudCell>, barCount: Int): List<List<HudCell>> {
+        if (barCount <= 1 || cells.isEmpty()) return listOf(cells)
+        val perBar = Math.ceil(cells.size.toDouble() / barCount).toInt().coerceAtLeast(1)
+        return (0 until barCount)
+            .map { i -> cells.drop(i * perBar).take(perBar) }
+            .filter { it.isNotEmpty() }
+    }
+
+    /** A content signature — when it's unchanged the HUD bitmap need not be re-rendered/re-uploaded. */
+    fun signature(cells: List<HudCell>): String =
+        cells.joinToString("|") { "${it.value}~${it.label}~${it.big}" }
+}

--- a/app/src/main/java/dev/zanderp/opencfmoto/HudRenderer.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/HudRenderer.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Alexandru <https://alexandru.rocks> and the OpenCfMoto contributors.
+// Part of OpenCfMoto. Free software under the GNU AGPL v3 or later; see LICENSE and NOTICE.
+package dev.zanderp.opencfmoto
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
+
+/**
+ * Renders one HUD bar's [HudCell]s to an opaque [Bitmap] that [AaCompositor] uploads to a GL texture
+ * and draws into the bar. Kept apart from [HudModel] (which is pure/host-tested) — this is the
+ * Android-graphics half. Fonts scale to the bar so it reads on both a thin side bar (800MT) and a
+ * wide bottom band; the bar background is black so it blends seamlessly with the letterbox.
+ */
+object HudRenderer {
+    private val valuePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+        textAlign = Paint.Align.CENTER
+    }
+    private val labelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.parseColor("#9AA0A6")
+        textAlign = Paint.Align.CENTER
+    }
+
+    fun render(bar: BarRect, cells: List<HudCell>): Bitmap {
+        val bmp = Bitmap.createBitmap(bar.w.coerceAtLeast(1), bar.h.coerceAtLeast(1), Bitmap.Config.ARGB_8888)
+        val c = Canvas(bmp)
+        c.drawColor(Color.BLACK)
+        if (cells.isEmpty()) return bmp
+        if (bar.vertical) {
+            val bandH = bar.h.toFloat() / cells.size
+            cells.forEachIndexed { i, cell ->
+                drawCell(c, bar.w / 2f, bandH * i + bandH / 2f, bar.w.toFloat(), bandH, cell)
+            }
+        } else {
+            val bandW = bar.w.toFloat() / cells.size
+            cells.forEachIndexed { i, cell ->
+                drawCell(c, bandW * i + bandW / 2f, bar.h / 2f, bandW, bar.h.toFloat(), cell)
+            }
+        }
+        return bmp
+    }
+
+    /** Draw one cell (big value over a small label), vertically centered at ([cx],[cy]). */
+    private fun drawCell(c: Canvas, cx: Float, cy: Float, availW: Float, availH: Float, cell: HudCell) {
+        valuePaint.color = if (cell.value == "HOT") Color.parseColor("#FF7043") else Color.WHITE
+        val vSize = fitText(valuePaint, cell.value, availW * 0.92f, availH * (if (cell.big) 0.52f else 0.42f))
+        val lSize = fitText(labelPaint, cell.label, availW * 0.92f, availH * 0.22f)
+        valuePaint.textSize = vSize
+        labelPaint.textSize = lSize
+        val gap = lSize * 0.4f
+        val totalH = vSize + gap + lSize
+        val top = cy - totalH / 2f
+        c.drawText(cell.value, cx, top + vSize, valuePaint)
+        c.drawText(cell.label, cx, top + vSize + gap + lSize, labelPaint)
+    }
+
+    /** Largest text size ≤ [target] that keeps [text] within [maxWidth]. */
+    private fun fitText(paint: Paint, text: String, maxWidth: Float, target: Float): Float {
+        val size = target.coerceAtLeast(8f)
+        paint.textSize = size
+        val w = paint.measureText(text)
+        return (if (w > maxWidth && w > 0) size * (maxWidth / w) else size).coerceAtLeast(8f)
+    }
+}

--- a/app/src/main/java/dev/zanderp/opencfmoto/HudSettingsActivity.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/HudSettingsActivity.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Alexandru <https://alexandru.rocks> and the OpenCfMoto contributors.
+// Part of OpenCfMoto. Free software under the GNU AGPL v3 or later; see LICENSE and NOTICE.
+package dev.zanderp.opencfmoto
+
+import android.content.Context
+import android.content.Intent
+import android.content.res.ColorStateList
+import android.os.Bundle
+import android.view.Gravity
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SwitchCompat
+import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.google.android.material.button.MaterialButton
+
+/**
+ * Dedicated settings screen for the on-dash rider HUD ([HudModel] / [AaCompositor]): master on/off,
+ * km/h·mph, and a per-element show/hide list. Every change is saved (per bike, via [VideoPrefs]) and
+ * applied live through [HudBus], so toggling reflects on the dash without a reconnect.
+ */
+class HudSettingsActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_hud_settings)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.hud_settings_root)) { v, insets ->
+            val b = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(v.paddingLeft, b.top, v.paddingRight, b.bottom)
+            insets
+        }
+
+        findViewById<MaterialButton>(R.id.hud_master_on).setOnClickListener { setEnabled(true) }
+        findViewById<MaterialButton>(R.id.hud_master_off).setOnClickListener { setEnabled(false) }
+        findViewById<MaterialButton>(R.id.unit_kmh).setOnClickListener { setUnit(SpeedUnit.KMH) }
+        findViewById<MaterialButton>(R.id.unit_mph).setOnClickListener { setUnit(SpeedUnit.MPH) }
+
+        buildElementRows()
+        refresh()
+    }
+
+    private fun setEnabled(on: Boolean) {
+        VideoPrefs.setHudEnabled(this, on)
+        HudBus.enabled = on
+        refresh()
+    }
+
+    private fun setUnit(unit: SpeedUnit) {
+        VideoPrefs.setSpeedUnit(this, unit)
+        HudBus.unit = unit
+        refresh()
+    }
+
+    /** One switch row per [HudElement], reflecting and updating the saved set + [HudBus] live. */
+    private fun buildElementRows() {
+        val container = findViewById<LinearLayout>(R.id.hud_elements_container)
+        container.removeAllViews()
+        val enabled = VideoPrefs.hudElements(this)
+        for (el in HudElement.values()) {
+            val row = LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT).apply { topMargin = dp(8) }
+            }
+            val label = TextView(this).apply {
+                text = el.label
+                setTextColor(ContextCompat.getColor(this@HudSettingsActivity, R.color.text_primary))
+                textSize = 16f
+                layoutParams = LinearLayout.LayoutParams(0, WRAP_CONTENT, 1f)
+            }
+            val sw = SwitchCompat(this).apply {
+                isChecked = el in enabled
+                setOnCheckedChangeListener { _, checked ->
+                    VideoPrefs.setHudElement(this@HudSettingsActivity, el, checked)
+                    HudBus.elements = VideoPrefs.hudElements(this@HudSettingsActivity)
+                }
+            }
+            row.addView(label)
+            row.addView(sw)
+            container.addView(row)
+        }
+    }
+
+    private fun refresh() {
+        highlight(VideoPrefs.hudEnabled(this),
+            R.id.hud_master_on to true,
+            R.id.hud_master_off to false)
+        highlight(VideoPrefs.speedUnit(this),
+            R.id.unit_kmh to SpeedUnit.KMH,
+            R.id.unit_mph to SpeedUnit.MPH)
+    }
+
+    /** Paint the segment matching [selected] in brand color; the rest stay neutral (mirrors Setup). */
+    private fun <T> highlight(selected: T, vararg pairs: Pair<Int, T>) {
+        val onColor = ContextCompat.getColor(this, R.color.brand_orange)
+        val onText = ContextCompat.getColor(this, R.color.on_brand)
+        val offColor = ContextCompat.getColor(this, R.color.surface_high)
+        val offText = ContextCompat.getColor(this, R.color.text_primary)
+        for ((id, value) in pairs) {
+            val btn = findViewById<MaterialButton>(id)
+            val on = value == selected
+            btn.backgroundTintList = ColorStateList.valueOf(if (on) onColor else offColor)
+            btn.setTextColor(if (on) onText else offText)
+        }
+    }
+
+    private fun dp(v: Int): Int = (v * resources.displayMetrics.density).toInt()
+
+    companion object {
+        fun start(ctx: Context) = ctx.startActivity(Intent(ctx, HudSettingsActivity::class.java))
+    }
+}

--- a/app/src/main/java/dev/zanderp/opencfmoto/HudStatsProvider.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/HudStatsProvider.kt
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Alexandru <https://alexandru.rocks> and the OpenCfMoto contributors.
+// Part of OpenCfMoto. Free software under the GNU AGPL v3 or later; see LICENSE and NOTICE.
+package dev.zanderp.opencfmoto
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.BatteryManager
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.PowerManager
+import android.os.SystemClock
+import android.text.format.DateFormat
+import java.util.Date
+
+/**
+ * Shared holder the [AaCompositor] reads to draw the on-dash HUD (idea B1). Written by
+ * [HudStatsProvider] (data) and [AndroidAutoService] (enabled/unit from prefs); read on the GL
+ * thread. Mirrors the app's process-global style ([AaVideoBridge], [BikeLink]).
+ */
+object HudBus {
+    @Volatile var enabled: Boolean = false
+    @Volatile var unit: SpeedUnit = SpeedUnit.KMH
+    @Volatile var elements: Set<HudElement> = HudElement.ALL
+    @Volatile var stats: RideStats = RideStats()
+    @Volatile var clock: String = ""
+}
+
+/**
+ * Feeds [HudBus] while projecting: a lightweight 1 Hz GPS listener (speed + trip distance/time,
+ * independent of the trip-logging/save path in [TripRecorder]), plus phone battery and thermal
+ * status. A 1 s ticker publishes a fresh [RideStats] even when the bike is stopped (no GPS updates)
+ * so the clock/battery still tick. Started/stopped with the AA session by [AndroidAutoService];
+ * no-op without the location permission.
+ */
+class HudStatsProvider(private val context: Context, private val log: (String) -> Unit) : LocationListener {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val lm = context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+    private val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+
+    @Volatile private var running = false
+
+    // Live ride accumulators (this projection session), updated on GPS fixes.
+    private var distanceMeters = 0.0
+    private var movingTimeMs = 0L
+    private var curSpeedKmh = 0
+    private var hasFix = false
+    private var lastFix: Location? = null
+    private var lastFixAt = 0L
+
+    private fun hasLocationPermission(): Boolean =
+        context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+
+    fun start() {
+        if (running) return
+        running = true
+        distanceMeters = 0.0; movingTimeMs = 0L; curSpeedKmh = 0; hasFix = false
+        lastFix = null; lastFixAt = 0L
+        if (hasLocationPermission() && lm?.isProviderEnabled(LocationManager.GPS_PROVIDER) == true) {
+            try {
+                lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, 1000L, 0f, this, Looper.getMainLooper())
+            } catch (_: SecurityException) {
+                log("[HUD] location permission missing — HUD speed will show '--'")
+            }
+        } else {
+            log("[HUD] GPS unavailable — HUD speed will show '--'")
+        }
+        handler.postDelayed(ticker, TICK_MS)
+        log("[HUD] stats provider started")
+    }
+
+    fun stop() {
+        if (!running) return
+        running = false
+        handler.removeCallbacks(ticker)
+        try { lm?.removeUpdates(this) } catch (_: Exception) {}
+        log("[HUD] stats provider stopped")
+    }
+
+    override fun onLocationChanged(location: Location) {
+        if (!running) return
+        val now = SystemClock.elapsedRealtime()
+        val prev = lastFix
+        val dtMs = if (prev != null && lastFixAt > 0) now - lastFixAt else 0L
+        val d = prev?.distanceTo(location) ?: 0f
+        val speedMs = if (location.hasSpeed()) location.speed
+            else if (dtMs in 1..5000) d / (dtMs / 1000f) else 0f
+        if (prev != null && speedMs >= MIN_MOVING_MS && dtMs in 1..5000) {
+            distanceMeters += d
+            movingTimeMs += dtMs
+        }
+        curSpeedKmh = (speedMs * 3.6f).coerceAtLeast(0f).toInt()
+        hasFix = true
+        lastFix = location
+        lastFixAt = now
+    }
+
+    override fun onProviderEnabled(provider: String) {}
+    override fun onProviderDisabled(provider: String) {}
+    @Deprecated("Deprecated in Java")
+    override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {}
+
+    private val ticker = object : Runnable {
+        override fun run() {
+            if (!running) return
+            try { publish() } catch (_: Exception) {}
+            handler.postDelayed(this, TICK_MS)
+        }
+    }
+
+    private fun publish() {
+        val (batteryPct, charging) = readBattery()
+        val thermal = try { powerManager.currentThermalStatus } catch (_: Exception) { 0 }
+        HudBus.stats = RideStats(
+            speedKmh = curSpeedKmh,
+            distanceMeters = distanceMeters,
+            movingTimeMs = movingTimeMs,
+            hasFix = hasFix,
+            batteryPct = batteryPct,
+            charging = charging,
+            thermalStatus = thermal,
+        )
+        HudBus.clock = DateFormat.getTimeFormat(context).format(Date())
+    }
+
+    /** Current battery percent + charging state from the sticky battery intent (no persistent receiver). */
+    private fun readBattery(): Pair<Int, Boolean> {
+        return try {
+            val i: Intent? = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            val level = i?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+            val scale = i?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+            val pct = if (level >= 0 && scale > 0) level * 100 / scale else -1
+            val status = i?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+            val charging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                status == BatteryManager.BATTERY_STATUS_FULL
+            pct to charging
+        } catch (_: Exception) {
+            -1 to false
+        }
+    }
+
+    companion object {
+        private const val TICK_MS = 1000L
+        private const val MIN_MOVING_MS = 0.8f   // ~2.9 km/h floor, matches TripRecorder
+    }
+}

--- a/app/src/main/java/dev/zanderp/opencfmoto/SetupActivity.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/SetupActivity.kt
@@ -104,6 +104,7 @@ class SetupActivity : AppCompatActivity() {
         findViewById<MaterialButton>(R.id.recovery_off).setOnClickListener { setAutoRecovery(false) }
         findViewById<MaterialButton>(R.id.logtrips_on).setOnClickListener { setLogTrips(true) }
         findViewById<MaterialButton>(R.id.logtrips_off).setOnClickListener { setLogTrips(false) }
+        findViewById<MaterialButton>(R.id.hud_settings_btn).setOnClickListener { HudSettingsActivity.start(this) }
         findViewById<MaterialButton>(R.id.nontouch_on).setOnClickListener { setForceNonTouch(true) }
         findViewById<MaterialButton>(R.id.nontouch_off).setOnClickListener { setForceNonTouch(false) }
         findViewById<MaterialButton>(R.id.profile_auto).setOnClickListener { setProfileOverride(ProfileOverride.AUTO) }

--- a/app/src/main/java/dev/zanderp/opencfmoto/VideoPrefs.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/VideoPrefs.kt
@@ -80,6 +80,9 @@ object VideoPrefs {
     private const val KEY_FIT = "screen_fit"
     private const val KEY_POWER = "power_mode"
     private const val KEY_RESOLUTION = "resolution_mode"
+    private const val KEY_HUD = "dash_hud"
+    private const val KEY_SPEED_UNIT = "speed_unit"
+    private const val KEY_HUD_ELEMENTS = "dash_hud_elements"
 
     private fun prefs(ctx: Context) =
         ctx.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
@@ -123,6 +126,47 @@ object VideoPrefs {
 
     fun setResolution(ctx: Context, mode: ResolutionMode) {
         BikeScope.putString(prefs(ctx), ctx, KEY_RESOLUTION, mode.name)
+    }
+
+    /**
+     * Dash HUD (idea B1): paint live speed/trip/phone telemetry into the FIT letterbox bars. On by
+     * default, but only ever visible when [ScreenFit.FIT] leaves bars to paint into (FILL/STRETCH
+     * cover the whole canvas).
+     */
+    fun hudEnabled(ctx: Context): Boolean =
+        BikeScope.getString(prefs(ctx), ctx, KEY_HUD, "true") == "true"
+
+    fun setHudEnabled(ctx: Context, on: Boolean) {
+        BikeScope.putString(prefs(ctx), ctx, KEY_HUD, on.toString())
+    }
+
+    /** Speed/distance unit for the HUD. Defaults to mph in the few mph countries, else km/h. */
+    fun speedUnit(ctx: Context): SpeedUnit {
+        val name = BikeScope.getString(prefs(ctx), ctx, KEY_SPEED_UNIT, defaultSpeedUnit().name)
+        return runCatching { SpeedUnit.valueOf(name!!) }.getOrDefault(defaultSpeedUnit())
+    }
+
+    fun setSpeedUnit(ctx: Context, unit: SpeedUnit) {
+        BikeScope.putString(prefs(ctx), ctx, KEY_SPEED_UNIT, unit.name)
+    }
+
+    private fun defaultSpeedUnit(): SpeedUnit {
+        val mph = setOf("US", "GB", "MM", "LR")   // imperial-ish road-speed countries
+        return if (java.util.Locale.getDefault().country.uppercase() in mph) SpeedUnit.MPH else SpeedUnit.KMH
+    }
+
+    /** Which HUD elements the rider has enabled (per bike). Unset = all on; an explicitly emptied set
+     *  stays empty (the rider turned everything off — the master toggle is separate). */
+    fun hudElements(ctx: Context): Set<HudElement> {
+        val def = HudElement.ALL.joinToString(",") { it.name }
+        val csv = BikeScope.getString(prefs(ctx), ctx, KEY_HUD_ELEMENTS, def) ?: def
+        return csv.split(",").mapNotNull { runCatching { HudElement.valueOf(it.trim()) }.getOrNull() }.toSet()
+    }
+
+    fun setHudElement(ctx: Context, element: HudElement, on: Boolean) {
+        val cur = hudElements(ctx).toMutableSet()
+        if (on) cur.add(element) else cur.remove(element)
+        BikeScope.putString(prefs(ctx), ctx, KEY_HUD_ELEMENTS, cur.joinToString(",") { it.name })
     }
 
     /**

--- a/app/src/main/res/layout/activity_hud_settings.xml
+++ b/app/src/main/res/layout/activity_hud_settings.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/hud_settings_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingBottom="24dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Dash HUD"
+            android:textColor="@color/text_primary"
+            android:textSize="26sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="12dp"
+            android:text="Live speed, trip and phone stats painted into the dashboard's black bars. Shows only when Screen fit is “Fit” (Setup ▸ Display) — other fits leave no bars to draw into."
+            android:textColor="@color/text_secondary"
+            android:textSize="14sp" />
+
+        <!-- ===== On / off + units ===== -->
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Card.OpenCfMoto"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Dash HUD"
+                    android:textColor="@color/text_secondary"
+                    android:textAllCaps="true"
+                    android:textSize="12sp"
+                    android:letterSpacing="0.08" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:baselineAligned="false"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/hud_master_on"
+                        style="@style/Widget.OpenCfMoto.Segment"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="4dp"
+                        android:layout_weight="1"
+                        android:text="On" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/hud_master_off"
+                        style="@style/Widget.OpenCfMoto.Segment"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="4dp"
+                        android:layout_weight="1"
+                        android:text="Off" />
+                </LinearLayout>
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="Units"
+                    android:textColor="@color/text_secondary"
+                    android:textAllCaps="true"
+                    android:textSize="12sp"
+                    android:letterSpacing="0.08" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:baselineAligned="false"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/unit_kmh"
+                        style="@style/Widget.OpenCfMoto.Segment"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="4dp"
+                        android:layout_weight="1"
+                        android:text="km/h" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/unit_mph"
+                        style="@style/Widget.OpenCfMoto.Segment"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="4dp"
+                        android:layout_weight="1"
+                        android:text="mph" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- ===== What to show ===== -->
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Card.OpenCfMoto"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Show on dash"
+                    android:textColor="@color/text_secondary"
+                    android:textAllCaps="true"
+                    android:textSize="12sp"
+                    android:letterSpacing="0.08" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginBottom="4dp"
+                    android:text="Pick what appears. Fewer items = bigger, clearer readouts — handy on thin or tall bars."
+                    android:textColor="@color/text_secondary"
+                    android:textSize="13sp" />
+
+                <LinearLayout
+                    android:id="@+id/hud_elements_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -931,6 +931,32 @@
                         android:text="Off" />
                 </LinearLayout>
 
+                <!-- Dash HUD (telemetry painted into the letterbox bars) -->
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="Dash HUD"
+                    android:textColor="@color/text_primary"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:layout_marginBottom="6dp"
+                    android:text="Show live speed, trip and phone stats in the dashboard's black bars. Only appears when Screen fit is set to “Fit” (Display, above) — other fits leave no bars."
+                    android:textColor="@color/text_secondary"
+                    android:textSize="13sp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/hud_settings_btn"
+                    style="@style/Widget.OpenCfMoto.Button.Tonal"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="HUD settings" />
+
                 <!-- Seamless auto-resume (overlay permission → background AA relaunch) -->
                 <TextView
                     android:layout_width="match_parent"

--- a/app/src/test/java/dev/zanderp/opencfmoto/HudModelTest.kt
+++ b/app/src/test/java/dev/zanderp/opencfmoto/HudModelTest.kt
@@ -1,0 +1,138 @@
+package dev.zanderp.opencfmoto
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Unit tests for the pure HUD model — geometry, formatting, layout ([HudModel.kt]). */
+class HudModelTest {
+
+    // ── bar detection ────────────────────────────────────────────────────────────────────────────
+
+    @Test fun fit_side_bars_on_800mt_geometry() {
+        // 800MT: AA 800x480 fit into a 1280x576 canvas → centered 960x576 → 160px side bars.
+        val bars = HudBars.detect(1280, 576, vpX = 160, vpY = 0, vpW = 960, vpH = 576, ScreenFit.FIT, minThickness = 48)
+        assertEquals(2, bars.size)
+        assertEquals(BarRect(0, 0, 160, 576), bars[0])       // left
+        assertEquals(BarRect(1120, 0, 160, 576), bars[1])    // right
+        assertTrue(bars[0].vertical)
+    }
+
+    @Test fun fit_top_bottom_bars() {
+        // AA shorter than canvas → top/bottom bars.
+        val bars = HudBars.detect(800, 600, vpX = 0, vpY = 60, vpW = 800, vpH = 480, ScreenFit.FIT, minThickness = 48)
+        assertEquals(2, bars.size)
+        assertEquals(BarRect(0, 0, 800, 60), bars[0])        // top
+        assertEquals(BarRect(0, 540, 800, 60), bars[1])      // bottom
+        assertFalse(bars[0].vertical)
+    }
+
+    @Test fun fill_and_stretch_have_no_bars() {
+        assertTrue(HudBars.detect(1280, 576, 160, 0, 960, 576, ScreenFit.FILL, 48).isEmpty())
+        assertTrue(HudBars.detect(1280, 576, 0, 0, 1280, 576, ScreenFit.STRETCH, 48).isEmpty())
+    }
+
+    @Test fun thin_bars_below_min_thickness_are_skipped() {
+        // 20px side bars, min 48 → nothing legible, no HUD.
+        val bars = HudBars.detect(1000, 576, vpX = 20, vpY = 0, vpW = 960, vpH = 576, ScreenFit.FIT, minThickness = 48)
+        assertTrue(bars.isEmpty())
+    }
+
+    @Test fun matched_aspect_yields_no_bars() {
+        val bars = HudBars.detect(960, 576, vpX = 0, vpY = 0, vpW = 960, vpH = 576, ScreenFit.FIT, minThickness = 48)
+        assertTrue(bars.isEmpty())
+    }
+
+    // ── formatting ───────────────────────────────────────────────────────────────────────────────
+
+    @Test fun speed_no_fix_is_dashes() {
+        assertEquals("--", HudFormat.speed(RideStats(speedKmh = 40, hasFix = false), SpeedUnit.KMH))
+    }
+
+    @Test fun speed_units() {
+        val s = RideStats(speedKmh = 100, hasFix = true)
+        assertEquals("100", HudFormat.speed(s, SpeedUnit.KMH))
+        assertEquals("62", HudFormat.speed(s, SpeedUnit.MPH)) // 100 km/h ≈ 62 mph
+    }
+
+    @Test fun distance_formatting() {
+        assertEquals("2.5 km", HudFormat.distance(2500.0, SpeedUnit.KMH))
+        assertEquals("42 km", HudFormat.distance(42_000.0, SpeedUnit.KMH))
+        assertEquals("1.6 mi", HudFormat.distance(2500.0, SpeedUnit.MPH))
+    }
+
+    @Test fun duration_formatting() {
+        assertEquals("0:05", HudFormat.duration(5_000))
+        assertEquals("1:05", HudFormat.duration(65_000))
+        assertEquals("1:01:05", HudFormat.duration(3_665_000))
+    }
+
+    @Test fun battery_formatting() {
+        assertEquals("84%", HudFormat.battery(84, charging = false))
+        assertEquals("84%+", HudFormat.battery(84, charging = true))
+        assertEquals("--", HudFormat.battery(-1, charging = false))
+    }
+
+    // ── stats + layout ───────────────────────────────────────────────────────────────────────────
+
+    @Test fun hot_flag_tracks_thermal_status() {
+        assertFalse(RideStats(thermalStatus = 1).hot)   // light
+        assertTrue(RideStats(thermalStatus = 2).hot)    // moderate
+        assertTrue(RideStats(thermalStatus = 4).hot)    // critical
+    }
+
+    @Test fun cells_hero_speed_first_and_temp_only_when_hot() {
+        val cool = HudLayout.cells(RideStats(speedKmh = 50, hasFix = true, thermalStatus = 0), SpeedUnit.KMH, "14:05")
+        assertTrue(cool.first().big)
+        assertEquals("50", cool.first().value)
+        assertFalse(cool.any { it.label == "temp" })
+
+        val hot = HudLayout.cells(RideStats(speedKmh = 50, hasFix = true, thermalStatus = 3), SpeedUnit.KMH, "14:05")
+        assertTrue(hot.any { it.label == "temp" && it.value == "HOT" })
+    }
+
+    @Test fun distribute_splits_two_bars_evenly_speed_in_first() {
+        val cells = HudLayout.cells(RideStats(speedKmh = 50, hasFix = true), SpeedUnit.KMH, "14:05") // 5 cells
+        val split = HudLayout.distribute(cells, 2)
+        assertEquals(2, split.size)
+        assertTrue(split[0].first().big)          // speed in the first bar
+        assertEquals(cells.size, split.sumOf { it.size })  // nothing lost
+    }
+
+    @Test fun distribute_single_bar_keeps_all() {
+        val cells = HudLayout.cells(RideStats(hasFix = true), SpeedUnit.KMH, "14:05")
+        assertEquals(listOf(cells), HudLayout.distribute(cells, 1))
+    }
+
+    @Test fun cells_respects_enabled_elements() {
+        val stats = RideStats(speedKmh = 50, hasFix = true, batteryPct = 80)
+        val onlySpeed = HudLayout.cells(stats, SpeedUnit.KMH, "14:05", setOf(HudElement.SPEED))
+        assertEquals(1, onlySpeed.size)
+        assertTrue(onlySpeed.first().big)
+
+        val speedAndBattery = HudLayout.cells(stats, SpeedUnit.KMH, "14:05", setOf(HudElement.SPEED, HudElement.BATTERY))
+        assertEquals(2, speedAndBattery.size)
+        assertTrue(speedAndBattery.any { it.label == "phone" })
+        assertFalse(speedAndBattery.any { it.label == "clock" })
+    }
+
+    @Test fun temp_needs_both_enabled_and_hot() {
+        val hot = RideStats(hasFix = true, thermalStatus = 3)
+        assertFalse(HudLayout.cells(hot, SpeedUnit.KMH, "14:05", setOf(HudElement.SPEED)).any { it.label == "temp" })
+        assertTrue(HudLayout.cells(hot, SpeedUnit.KMH, "14:05", setOf(HudElement.TEMP)).any { it.label == "temp" })
+        val cool = RideStats(hasFix = true, thermalStatus = 0)
+        assertFalse(HudLayout.cells(cool, SpeedUnit.KMH, "14:05", setOf(HudElement.TEMP)).any { it.label == "temp" })
+    }
+
+    @Test fun empty_enabled_set_yields_no_cells() {
+        assertTrue(HudLayout.cells(RideStats(hasFix = true), SpeedUnit.KMH, "14:05", emptySet()).isEmpty())
+    }
+
+    @Test fun signature_changes_with_content() {
+        val a = HudLayout.cells(RideStats(speedKmh = 50, hasFix = true), SpeedUnit.KMH, "14:05")
+        val b = HudLayout.cells(RideStats(speedKmh = 51, hasFix = true), SpeedUnit.KMH, "14:05")
+        assertEquals(HudLayout.signature(a), HudLayout.signature(a))
+        assertTrue(HudLayout.signature(a) != HudLayout.signature(b))
+    }
+}


### PR DESCRIPTION
## What & why

Turns the wasted **letterbox bars** into a **rider HUD**. When the screen fit is **Fit**, the AA video is centered into the bike canvas leaving black bars (e.g. the 800MT's two ~160px side bars). Instead of wasting them, this paints live telemetry there — **speed** (hero), **trip distance/time**, **clock**, **phone battery**, and a **hot-phone warning** — *without moving or resizing the AA image*. It's a motorcycle-specific dash no stock Android Auto head unit offers, built on the compositor + trip plumbing already in the app. (Idea **B1** from the roadmap.)

## How it works

- **`HudModel` (pure, unit-tested):** letterbox bar-detection from the compositor viewport, value formatting (km/h·mph, distance, duration, battery), and cell layout/distribution across the bars.
- **`HudStatsProvider`:** a lightweight **1 Hz GPS listener** while projecting (speed + trip distance/time, independent of the trip-logging save path), plus **battery** (`BatteryManager`) and **thermal** (`PowerManager` — the same signal the adaptive throttle reads). Publishes a `RideStats` to a shared `HudBus`.
- **`AaCompositor`:** a second plain-2D GL program draws a `Canvas`-rendered bitmap **per bar**, over the AA frame, on the **bike surface only**. The bitmap is re-rendered/re-uploaded **only when a displayed value changes (~1 Hz)**, so a static screen barely touches the idle-encoder throttle. The whole HUD draw is guarded so a glitch can never take down the video path.

## Scope & behaviour

- Renders **only in FIT** mode (FILL/STRETCH cover the whole canvas → no bars) and only in bars thick enough to read.
- **Per-bike toggle (default on)** + **km/h·mph** unit in Setup ▸ Dash HUD, applied **live via `HudBus`** (no reconnect). Unit defaults from locale.
- Uses the **existing** location permission — nothing new. Distance/time are for the current projection session.
- Bike surface only (not the in-app phone preview) for v1.

## Testing

- **`HudModelTest` — 16 unit tests** (bar geometry incl. the 800MT side-bar case, FILL/STRETCH = no bars, thin-bar skip, all formatters, layout distribution). Plus the existing `AdaptivePolicyTest`. All pass.
- `./gradlew testDebugUnitTest assembleDebug` → **BUILD SUCCESSFUL.**
- ⚠️ **Not yet ridden.** The GL text rendering, bar geometry, and legibility on a real dash want one on-bike pass — the pure geometry/format/layout is covered by tests, but the pixels aren't verified on hardware yet.

## Notes for review

- **v1 layout** stacks cells per bar (speed lands in the first/left bar). Horizontal (top/bottom) bars get a basic row layout; the primary target is the 800MT side bars.
- Follow-ups (not in this PR): HUD on the phone preview too, next-turn glance (needs AA nav data we don't tap yet), richer layout tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
