### PR TITLE
Add "Match panel aspect": render Android Auto at a non-standard dash aspect ratio via AA margins

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,6 +99,10 @@
             android:name=".ScreenMarginsActivity"
             android:exported="false" />
         <activity
+            android:name=".CustomResolutionActivity"
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize" />
+        <activity
             android:name=".AboutActivity"
             android:exported="false" />
         <service

--- a/app/src/main/java/dev/zanderp/opencfmoto/AaCompositor.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/AaCompositor.kt
@@ -63,7 +63,13 @@ class AaCompositor(private val log: (String) -> Unit) {
     private var aPosition = 0
     private var aTexCoord = 0
     private var uTexMatrix = 0
+    private var uCrop = 0
     private var textureId = 0
+
+    // Fraction of the coded AA frame that holds content (1.0 = whole frame). <1 when match-panel-aspect
+    // margins are advertised: AA draws its UI into a sub-rect, so we sample only that region.
+    @Volatile private var cropU = 1f
+    @Volatile private var cropV = 1f
     private lateinit var surfaceTexture: SurfaceTexture
 
     /** Where the AA decoder renders. Valid after [start]. */
@@ -119,6 +125,11 @@ class AaCompositor(private val log: (String) -> Unit) {
                 initGl()
                 val spec = BikeProfileHolder.aaVideo
                 bufW = spec.width; bufH = spec.height
+                // Match-aspect margins are known before AA starts, so the in-app Dash view preview is
+                // aspect-correct immediately (even before the bike connects / sets the bike canvas).
+                val m = BikeProfileHolder.aaContentMargins
+                cropU = ((spec.width - m.marginW).toFloat() / spec.width).coerceIn(0.05f, 1f)
+                cropV = ((spec.height - m.marginH).toFloat() / spec.height).coerceIn(0.05f, 1f)
                 surfaceTexture = SurfaceTexture(textureId)
                 surfaceTexture.setDefaultBufferSize(spec.width, spec.height)
                 surfaceTexture.setOnFrameAvailableListener({ handler.post { onFrame() } }, handler)
@@ -208,10 +219,14 @@ class AaCompositor(private val log: (String) -> Unit) {
         try { latch.await(1, java.util.concurrent.TimeUnit.SECONDS) } catch (_: Exception) {}
     }
 
-    /** Aspect-fit the AA source ([bufW]x[bufH]) into the preview surface ([previewW]x[previewH]). */
+    /**
+     * Aspect-fit the AA source into the preview surface ([previewW]x[previewH]). Uses the *usable*
+     * area (coded frame minus match-aspect margins, i.e. scaled by [cropU]/[cropV]) so the in-app
+     * Dash view matches what the compositor actually samples and isn't stretched.
+     */
     private fun computePreviewRect() {
         if (previewW == 0 || previewH == 0 || bufW == 0 || bufH == 0) return
-        val srcAspect = bufW.toFloat() / bufH
+        val srcAspect = (bufW * cropU) / (bufH * cropV)
         val viewAspect = previewW.toFloat() / previewH
         if (srcAspect < viewAspect) {           // source narrower → fit height, bars left/right
             ppH = previewH; ppW = Math.round(previewH * srcAspect)
@@ -277,6 +292,19 @@ class AaCompositor(private val log: (String) -> Unit) {
         }
         vpX = mL + (areaW - vpW) / 2
         vpY = mT + (areaH - vpH) / 2
+    }
+
+    /**
+     * Sample only [cu]x[cv] (fractions, top-left origin) of the coded AA frame — the usable content
+     * area when match-panel-aspect margins are advertised. 1,1 = whole frame (default).
+     */
+    fun setSourceCrop(cu: Float, cv: Float) {
+        handler.post {
+            cropU = cu.coerceIn(0.05f, 1f)
+            cropV = cv.coerceIn(0.05f, 1f)
+            computePreviewRect()
+            if (hasContent) drawFrame()
+        }
     }
 
     /** Re-apply [ScreenMargins] after the rider changes them mid-session. */
@@ -367,6 +395,7 @@ class AaCompositor(private val log: (String) -> Unit) {
         GLES20.glEnableVertexAttribArray(aTexCoord)
 
         GLES20.glUniformMatrix4fv(uTexMatrix, 1, false, texMatrix, 0)
+        GLES20.glUniform2f(uCrop, cropU, cropV)
 
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
         GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
@@ -429,12 +458,18 @@ class AaCompositor(private val log: (String) -> Unit) {
     private fun initGl() {
         val vs = """
             uniform mat4 uTexMatrix;
+            uniform vec2 uCrop;
             attribute vec4 aPosition;
             attribute vec4 aTexCoord;
             varying vec2 vTexCoord;
             void main() {
                 gl_Position = aPosition;
-                vTexCoord = (uTexMatrix * aTexCoord).xy;
+                // AA splits margin_width/height evenly (DHU: marginwidth 280 → 140+140), so its UI is
+                // CENTERED inside the coded frame. Sample the centered usable region on both axes; the
+                // (1-crop)*0.5 offset is symmetric, so SurfaceTexture's y-flip needs no special case.
+                float u = (1.0 - uCrop.x) * 0.5 + aTexCoord.x * uCrop.x;
+                float v = (1.0 - uCrop.y) * 0.5 + aTexCoord.y * uCrop.y;
+                vTexCoord = (uTexMatrix * vec4(u, v, aTexCoord.z, aTexCoord.w)).xy;
             }
         """.trimIndent()
         val fs = """
@@ -448,6 +483,7 @@ class AaCompositor(private val log: (String) -> Unit) {
         aPosition = GLES20.glGetAttribLocation(program, "aPosition")
         aTexCoord = GLES20.glGetAttribLocation(program, "aTexCoord")
         uTexMatrix = GLES20.glGetUniformLocation(program, "uTexMatrix")
+        uCrop = GLES20.glGetUniformLocation(program, "uCrop")
         Matrix.setIdentityM(texMatrix, 0)
 
         val ids = IntArray(1)

--- a/app/src/main/java/dev/zanderp/opencfmoto/BikeProfile.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/BikeProfile.kt
@@ -29,6 +29,42 @@ data class AaVideoSpec(val resolution: AaResolution, val dpi: Int) {
     val height: Int get() = resolution.h
 }
 
+/**
+ * Unused pixels of the coded AA frame, advertised via the AAP VideoConfiguration
+ * `marginWidth`/`marginHeight` fields. Android Auto then renders its UI into the remaining
+ * `(width - marginW) x (height - marginH)` area — the standard way to make AA draw at a panel's
+ * aspect ratio when none of the fixed coded sizes matches it. The compositor samples only that
+ * usable sub-rect (see [AaCompositor]).
+ */
+data class AaMargins(val marginW: Int, val marginH: Int) {
+    val any: Boolean get() = marginW > 0 || marginH > 0
+
+    companion object {
+        val NONE = AaMargins(0, 0)
+
+        /**
+         * Margins that shrink [coded] so the usable area matches [targetW]:[targetH], trimming only
+         * the axis that is too long (keeping one axis at full coded size to lose the least detail).
+         */
+        fun forAspect(coded: AaVideoSpec, targetW: Int, targetH: Int): AaMargins {
+            if (targetW <= 0 || targetH <= 0) return NONE
+            val cw = coded.width
+            val ch = coded.height
+            val codedAspect = cw.toDouble() / ch
+            val targetAspect = targetW.toDouble() / targetH
+            return if (codedAspect < targetAspect) {
+                // coded is too tall/narrow for the target → trim height.
+                val usableH = Math.round(cw * targetH.toDouble() / targetW).toInt().coerceIn(16, ch)
+                AaMargins(0, (ch - usableH).coerceAtLeast(0))
+            } else {
+                // coded is too wide for the target → trim width.
+                val usableW = Math.round(ch * targetW.toDouble() / targetH).toInt().coerceIn(16, cw)
+                AaMargins((cw - usableW).coerceAtLeast(0), 0)
+            }
+        }
+    }
+}
+
 interface BikeProfile {
     /** Human-readable label — appears in bike-test logs so a capture is self-describing. */
     val name: String
@@ -185,6 +221,13 @@ object BikeProfileHolder {
     @Volatile var aaVideoOverride: AaVideoSpec? = null
 
     /**
+     * Margins advertised to Android Auto so it renders at the dash panel's aspect ratio (see
+     * [AaMargins]). Set before AA starts in [MainActivity]; read by [dev.zanderp.opencfmoto.aa.ServiceDiscoveryResponse]
+     * (advertise) and the compositor (crop the source to the usable area). [AaMargins.NONE] = off.
+     */
+    @Volatile var aaContentMargins: AaMargins = AaMargins.NONE
+
+    /**
      * Setup ▸ "Disable touchscreen" — when true, never advertise a touchscreen to Android Auto
      * (focus/knob UI) even if the active profile claims touch. Synced from [AppSettings.forceNonTouch].
      */
@@ -198,6 +241,11 @@ object BikeProfileHolder {
 
     /** The effective Android Auto video spec: the user override if set, else the active profile's. */
     val aaVideo: AaVideoSpec get() = aaVideoOverride ?: active.aaVideo
+
+    /** Usable AA content size (coded frame minus [aaContentMargins]) — the aspect-correct area the
+     *  compositor and the in-app Dash view actually show. Equals the coded size when margins are off. */
+    val aaUsableWidth: Int get() = (aaVideo.width - aaContentMargins.marginW).coerceIn(1, aaVideo.width)
+    val aaUsableHeight: Int get() = (aaVideo.height - aaContentMargins.marginH).coerceIn(1, aaVideo.height)
 
     /** Whether AA / CLIENT_INFO should advertise a touchscreen (profile ∧ ¬forceNonTouch). */
     val advertisesScreenTouch: Boolean get() = !forceNonTouch && active.supportsScreenTouch

--- a/app/src/main/java/dev/zanderp/opencfmoto/BikeScope.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/BikeScope.kt
@@ -43,6 +43,15 @@ object BikeScope {
         p.edit().putBoolean(scopedKey(ctx, base), value).apply()
     }
 
+    fun getInt(p: SharedPreferences, ctx: Context, base: String, def: Int): Int {
+        suffix(ctx)?.let { val k = "$base#$it"; if (p.contains(k)) return p.getInt(k, def) }
+        return p.getInt(base, def)
+    }
+
+    fun putInt(p: SharedPreferences, ctx: Context, base: String, value: Int) {
+        p.edit().putInt(scopedKey(ctx, base), value).apply()
+    }
+
     /** Drop the selected bike's scoped value so the setting reverts to its fallback/default. */
     fun remove(p: SharedPreferences, ctx: Context, base: String) {
         p.edit().remove(scopedKey(ctx, base)).apply()

--- a/app/src/main/java/dev/zanderp/opencfmoto/CustomResolutionActivity.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/CustomResolutionActivity.kt
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Alexandru <https://alexandru.rocks> and the OpenCfMoto contributors.
+// Part of OpenCfMoto. Free software under the GNU AGPL v3 or later; see LICENSE and NOTICE.
+package dev.zanderp.opencfmoto
+
+import android.content.Context
+import android.content.Intent
+import android.content.res.ColorStateList
+import android.os.Bundle
+import android.widget.EditText
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.google.android.material.button.MaterialButton
+
+/**
+ * Match-panel-aspect page: make Android Auto render at the dash panel's aspect ratio by advertising
+ * unused margins (AAP marginWidth/marginHeight), which the compositor then crops to. Applies on the
+ * next connect. See [VideoPrefs] (KEY_MATCH_ASPECT/ASPECT_*) and [AaMargins].
+ */
+class CustomResolutionActivity : AppCompatActivity() {
+
+    private var matchOn = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_custom_resolution)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.custom_res_root)) { v, insets ->
+            val b = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(b.left, b.top, b.right, b.bottom)
+            insets
+        }
+
+        val (mw, mh) = VideoPrefs.aspectTarget(this)
+        findViewById<EditText>(R.id.match_w).setText(mw.toString())
+        findViewById<EditText>(R.id.match_h).setText(mh.toString())
+        matchOn = VideoPrefs.matchAspect(this)
+
+        findViewById<MaterialButton>(R.id.match_on).setOnClickListener { matchOn = true; refresh() }
+        findViewById<MaterialButton>(R.id.match_off).setOnClickListener { matchOn = false; refresh() }
+        findViewById<MaterialButton>(R.id.btn_custom_res_save).setOnClickListener { save() }
+        findViewById<MaterialButton>(R.id.btn_custom_res_done).setOnClickListener { save(); finish() }
+
+        listOf(R.id.match_w, R.id.match_h).forEach { id ->
+            findViewById<EditText>(id).addTextChangedListener(SimpleWatcher { refreshMatchNote() })
+        }
+        refresh()
+    }
+
+    private fun readInt(id: Int, def: Int): Int =
+        findViewById<EditText>(id).text.toString().trim().toIntOrNull() ?: def
+
+    private fun save() {
+        val (mw0, mh0) = VideoPrefs.aspectTarget(this)
+        VideoPrefs.setMatchAspect(this, matchOn, readInt(R.id.match_w, mw0), readInt(R.id.match_h, mh0))
+        Toast.makeText(this, "Saved (applies next connect)", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun refresh() {
+        highlight(matchOn, R.id.match_on to true, R.id.match_off to false)
+        refreshMatchNote()
+    }
+
+    /** Show the margins + usable content size that match-aspect will produce for the current AA size. */
+    private fun refreshMatchNote() {
+        val (mw0, mh0) = VideoPrefs.aspectTarget(this)
+        val tw = readInt(R.id.match_w, mw0)
+        val th = readInt(R.id.match_h, mh0)
+        val coded = VideoPrefs.resolution(this).spec ?: BikeProfileHolder.aaVideo
+        val m = AaMargins.forAspect(coded, tw, th)
+        val uw = coded.width - m.marginW
+        val uh = coded.height - m.marginH
+        findViewById<TextView>(R.id.match_note).text =
+            "AA coded ${coded.width}×${coded.height} → margins ${m.marginW}×${m.marginH}, " +
+            "content ${uw}×${uh} (aspect ${"%.3f".format(uw.toDouble() / uh)}). Fills the panel; Screen fit no longer matters."
+    }
+
+    private fun <T> highlight(selected: T, vararg pairs: Pair<Int, T>) {
+        val onColor = ContextCompat.getColor(this, R.color.brand_orange)
+        val onText = ContextCompat.getColor(this, R.color.on_brand)
+        val offColor = ContextCompat.getColor(this, R.color.surface_high)
+        val offText = ContextCompat.getColor(this, R.color.text_primary)
+        for ((id, value) in pairs) {
+            val btn = findViewById<MaterialButton>(id)
+            val on = value == selected
+            btn.backgroundTintList = ColorStateList.valueOf(if (on) onColor else offColor)
+            btn.setTextColor(if (on) onText else offText)
+        }
+    }
+
+    private class SimpleWatcher(val onChange: () -> Unit) : android.text.TextWatcher {
+        override fun afterTextChanged(s: android.text.Editable?) = onChange()
+        override fun beforeTextChanged(s: CharSequence?, a: Int, b: Int, c: Int) {}
+        override fun onTextChanged(s: CharSequence?, a: Int, b: Int, c: Int) {}
+    }
+
+    companion object {
+        fun start(ctx: Context) {
+            ctx.startActivity(Intent(ctx, CustomResolutionActivity::class.java))
+        }
+    }
+}

--- a/app/src/main/java/dev/zanderp/opencfmoto/HudViewActivity.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/HudViewActivity.kt
@@ -199,9 +199,10 @@ class HudViewActivity : AppCompatActivity() {
     private fun mapToSource(vx: Float, vy: Float): Pair<Int, Int>? {
         val vw = surface.width
         val vh = surface.height
-        val spec = BikeProfileHolder.aaVideo
-        val sw = spec.width
-        val sh = spec.height
+        // Usable (aspect-correct) content area — matches AaCompositor's preview fit and match-aspect
+        // crop. Touches map into the usable region, which is the content's coded coordinate space.
+        val sw = BikeProfileHolder.aaUsableWidth
+        val sh = BikeProfileHolder.aaUsableHeight
         if (vw == 0 || vh == 0 || sw == 0 || sh == 0) return null
 
         val srcAspect = sw.toFloat() / sh

--- a/app/src/main/java/dev/zanderp/opencfmoto/MainActivity.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/MainActivity.kt
@@ -99,6 +99,10 @@ class MainActivity : AppCompatActivity() {
         val autoGeo = if (userOverride == null) DashMemory.specFor(this, qr.ssid, BikeProfileHolder.active) else null
         BikeProfileHolder.aaVideoOverride = userOverride ?: autoGeo
         val spec = BikeProfileHolder.aaVideo
+        BikeProfileHolder.aaContentMargins = VideoPrefs.aaMarginsFor(this, spec)
+        val aspectNote = BikeProfileHolder.aaContentMargins.let {
+            if (it.any) " [match-aspect: margins ${it.marginW}x${it.marginH}]" else ""
+        }
         val note = when {
             userOverride != null -> " (override: ${VideoPrefs.resolution(this).label})"
             autoGeo != null -> " (auto-orientation from last connect)"
@@ -108,7 +112,7 @@ class MainActivity : AppCompatActivity() {
         val ov = BikeProfileHolder.profileOverride
         val ovNote = if (ov != ProfileOverride.AUTO) " [profile override: ${ov.shortLabel}]" else ""
         log("→ bike profile (QR ssid=${qr.ssid} modelId=${qr.modelId}): ${BikeProfileHolder.active.name} " +
-            "→ AA ${spec.width}x${spec.height} @${spec.dpi}dpi$note$touchNote$ovNote")
+            "→ AA ${spec.width}x${spec.height} @${spec.dpi}dpi$note$touchNote$ovNote$aspectNote")
     }
 
     /** Start the Android Auto → bike projection for [qr]. Shared by the one-tap Connect reconnect

--- a/app/src/main/java/dev/zanderp/opencfmoto/SetupActivity.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/SetupActivity.kt
@@ -125,6 +125,7 @@ class SetupActivity : AppCompatActivity() {
         findViewById<MaterialButton>(R.id.profile_nk_adv).setOnClickListener { setProfileOverride(ProfileOverride.NK_ADV) }
         findViewById<MaterialButton>(R.id.profile_clc450).setOnClickListener { setProfileOverride(ProfileOverride.CLC450) }
         findViewById<MaterialButton>(R.id.btn_screen_margins).setOnClickListener { ScreenMarginsActivity.start(this) }
+        findViewById<MaterialButton>(R.id.btn_custom_resolution).setOnClickListener { CustomResolutionActivity.start(this) }
         findViewById<MaterialButton>(R.id.transport_auto).setOnClickListener { setTransport(WifiTransport.AUTO) }
         findViewById<MaterialButton>(R.id.transport_ap).setOnClickListener { setTransport(WifiTransport.AP) }
         findViewById<MaterialButton>(R.id.transport_p2p).setOnClickListener { setTransport(WifiTransport.P2P) }

--- a/app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/VideoPipeline.kt
@@ -199,9 +199,17 @@ class VideoPipeline(
         if (surf != null) {
             val fit = VideoPrefs.fit(context)
             val power = VideoPrefs.power(context)
+            // Match-panel-aspect: AA drew its UI into (coded - margins); sample only that sub-rect so
+            // the aspect-correct content — not the padded coded frame — is mapped onto the bike canvas.
+            val margins = BikeProfileHolder.aaContentMargins
+            val usableW = (src.width - margins.marginW).coerceIn(16, src.width)
+            val usableH = (src.height - margins.marginH).coerceIn(16, src.height)
             aaCompositor?.setFrameCap(power.fps)
-            aaCompositor?.setOutput(surf, w, h, src.width, src.height, fit)
-            log("[VIDEO] bike canvas ${w}x$h configured; AA source ${src.width}x${src.height} → fit=$fit power=${power.fps}fps")
+            aaCompositor?.setSourceCrop(usableW.toFloat() / src.width, usableH.toFloat() / src.height)
+            aaCompositor?.setOutput(surf, w, h, usableW, usableH, fit)
+            log("[VIDEO] bike canvas ${w}x$h configured; AA source ${src.width}x${src.height} " +
+                "usable ${usableW}x$usableH (margins ${margins.marginW}x${margins.marginH}) → " +
+                "fit=$fit power=${power.fps}fps")
         }
     }
 

--- a/app/src/main/java/dev/zanderp/opencfmoto/VideoPrefs.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/VideoPrefs.kt
@@ -81,6 +81,13 @@ object VideoPrefs {
     private const val KEY_POWER = "power_mode"
     private const val KEY_RESOLUTION = "resolution_mode"
 
+    // Match panel aspect (AA margins): make Android Auto render at a target aspect ratio via the
+    // AAP marginWidth/marginHeight fields; the compositor then samples only the usable sub-rect.
+    // Default target is the 1000 MT-X panel (800x951).
+    private const val KEY_MATCH_ASPECT = "match_aspect_on"
+    private const val KEY_ASPECT_W = "match_aspect_w"
+    private const val KEY_ASPECT_H = "match_aspect_h"
+
     private fun prefs(ctx: Context) =
         ctx.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
@@ -123,6 +130,28 @@ object VideoPrefs {
 
     fun setResolution(ctx: Context, mode: ResolutionMode) {
         BikeScope.putString(prefs(ctx), ctx, KEY_RESOLUTION, mode.name)
+    }
+
+    fun matchAspect(ctx: Context): Boolean =
+        BikeScope.getBoolean(prefs(ctx), ctx, KEY_MATCH_ASPECT, false)
+
+    /** Target aspect for [matchAspect], as (width, height). Default = 1000 MT-X panel 800×951. */
+    fun aspectTarget(ctx: Context): Pair<Int, Int> = Pair(
+        BikeScope.getInt(prefs(ctx), ctx, KEY_ASPECT_W, 800),
+        BikeScope.getInt(prefs(ctx), ctx, KEY_ASPECT_H, 951),
+    )
+
+    fun setMatchAspect(ctx: Context, on: Boolean, w: Int, h: Int) {
+        BikeScope.putBoolean(prefs(ctx), ctx, KEY_MATCH_ASPECT, on)
+        BikeScope.putInt(prefs(ctx), ctx, KEY_ASPECT_W, w.coerceIn(16, 8192))
+        BikeScope.putInt(prefs(ctx), ctx, KEY_ASPECT_H, h.coerceIn(16, 8192))
+    }
+
+    /** Margins to advertise for the current AA [spec] under the match-aspect setting, or NONE. */
+    fun aaMarginsFor(ctx: Context, spec: AaVideoSpec): AaMargins {
+        if (!matchAspect(ctx)) return AaMargins.NONE
+        val (tw, th) = aspectTarget(ctx)
+        return AaMargins.forAspect(spec, tw, th)
     }
 
     /**

--- a/app/src/main/java/dev/zanderp/opencfmoto/aa/ServiceDiscoveryResponse.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/aa/ServiceDiscoveryResponse.kt
@@ -62,8 +62,10 @@ class ServiceDiscoveryResponse
                             codecResolution = protoResolution(spec.resolution)
                             frameRate = Control.Service.MediaSinkService.VideoConfiguration.VideoFrameRateType._30
                             setDensity(spec.dpi)
-                            setMarginWidth(0)
-                            setMarginHeight(0)
+                            // Match-panel-aspect: advertise the unused margin so AA renders its UI at
+                            // the panel's aspect inside the fixed coded frame (see AaMargins).
+                            setMarginWidth(BikeProfileHolder.aaContentMargins.marginW)
+                            setMarginHeight(BikeProfileHolder.aaContentMargins.marginH)
                             setVideoCodecType(Media.MediaCodecType.MEDIA_CODEC_VIDEO_H264_BP)
                         }.build()
                     )

--- a/app/src/main/res/layout/activity_custom_resolution.xml
+++ b/app/src/main/res/layout/activity_custom_resolution.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/custom_res_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingBottom="24dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Match panel aspect"
+            android:textColor="@color/text_primary"
+            android:textSize="26sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:text="Forces Android Auto to render at your panel's aspect ratio by advertising unused margins, then crops to the usable area — so the map fills the whole screen with no crop or distortion. Enter your panel's real size (e.g. 800 × 951 for the 1000 MT-X). Applies on next connect."
+            android:textColor="@color/text_secondary"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/match_on"
+                style="@style/Widget.OpenCfMoto.Segment"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="4dp"
+                android:layout_weight="1"
+                android:text="Match aspect" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/match_off"
+                style="@style/Widget.OpenCfMoto.Segment"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_weight="1"
+                android:text="Off" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
+            <EditText
+                android:id="@+id/match_w"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="4dp"
+                android:layout_weight="1"
+                android:hint="Panel width"
+                android:importantForAutofill="no"
+                android:inputType="number"
+                android:textColor="@color/text_primary"
+                android:textColorHint="@color/text_secondary" />
+            <EditText
+                android:id="@+id/match_h"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_weight="1"
+                android:hint="Panel height"
+                android:importantForAutofill="no"
+                android:inputType="number"
+                android:textColor="@color/text_primary"
+                android:textColorHint="@color/text_secondary" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/match_note"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:textColor="@color/text_secondary"
+            android:textSize="13sp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_custom_res_save"
+            style="@style/Widget.OpenCfMoto.Segment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="Save" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_custom_res_done"
+            style="@style/Widget.OpenCfMoto.Segment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Done" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -457,6 +457,14 @@
                     android:textSize="12sp"
                     android:lineSpacingExtra="2dp" />
 
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_custom_resolution"
+                    style="@style/Widget.OpenCfMoto.Segment"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="Custom resolution…" />
+
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
## What this adds

A new optional **"Match panel aspect"** mode that makes Android Auto render its UI at the dashboard panel's real aspect ratio, so projection fills the whole screen with **no cropping and no distortion** — even on dashes whose shape matches none of Android Auto's fixed video sizes (e.g. the CFMoto 1000 MT-X, a near-square ~800×951 panel).

## Why

Today the AA video can only be *placed* on the dash, not *re-flowed*:

- **Fill** — fills the panel but crops the AA top card + bottom nav bar
- **Fit** — shows the whole UI but adds black pillar bars on the sides
- **Stretch** — fills but distorts (~1.5× horizontal stretch)

`ScreenMargins` doesn't help here — it's a compositor-side inset that just crops the already-rendered frame, so it can only trim more, never fix the aspect. I tried it directly on the 1000 MT-X and it does not work correctly on this panel. On a near-square dash (~0.84) there is no setting that gives full-screen + whole-UI + no-distortion at once.

The root cause: AA only encodes fixed sizes (1080×1920, etc.). The one AAP knob that changes the aspect ratio AA actually *renders* at is `marginWidth`/`marginHeight` in the `VideoConfiguration` — and these were hardcoded to `0`, so they were never used.

## How it works

1. **Advertise real AAP margins** computed from the target panel aspect. Gearhead then re-flows and renders its **entire UI** into the reduced *usable* area `(coded − margins)`, whose aspect equals the panel's, and pads the leftover with a solid color.
2. **Sample the centered usable sub-rect** in the compositor and map it 1:1 onto the dash canvas. AA splits the margin evenly and **centers** its UI, so sampling from the top-left clips the bottom nav bar — offsetting the texture coordinates by `(1 − crop)/2` per axis fixes it. (The offset is symmetric, so the SurfaceTexture Y-flip needs no special case.)

Worked example — CFMoto 1000 MT-X (dash requests `REQ_CONFIG_CAPTURE 800×951`):

```
coded 1080×1920, target 800×951
marginHeight = 1920 − round(1080 × 951/800) = 1920 − 1284 = 636   (marginWidth 0)
→ usable 1080×1284 (aspect 0.841 ≈ panel) → mapped 1:1 onto 800×951
```

Result: edge-to-edge, whole UI, no distortion. "Screen fit" becomes irrelevant while this is on.

## Changes

- **AaMargins** (`BikeProfile`): computes margins that shrink a coded size to a target aspect, trimming only the axis that is too long.
- **ServiceDiscoveryResponse**: advertises `marginWidth`/`marginHeight` from the active config.
- **AaCompositor**: samples only the centered usable sub-rect (GL vertex-shader `uCrop` uniform); uses the usable size for the in-app Dash view preview aspect.
- **VideoPipeline**: sizes the compositor output + source crop to the usable area.
- **HudViewActivity**: maps touches into the usable coordinate space.
- **MainActivity**: computes the margins before AA starts.
- **VideoPrefs / BikeScope**: per-bike persistence (match on/off + target W×H).
- **CustomResolutionActivity** + layout: UI to toggle the mode and enter the panel size, with a live preview of the resulting margins/usable size.

## How to use

Setup → Custom resolution… → **Match aspect = On**, panel **800 × 951** (for the 1000 MT-X); AA resolution = **Portrait 1080×1920**. Applies on next connect.

## Testing

Verified live on a **CFMoto 1000 MT-X** (CFDL26 / MotoPlay Portrait), wireless, ~35 fps decode, stable link. Full-screen with the entire AA UI visible and no distortion.
