### PR TITLE
Declare microphone foreground service type for Android 14+ compatibility

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Best-effort close of the official CFMoto/EasyConnect app when it's holding the bike's
@@ -112,7 +113,7 @@
         <service
             android:name=".AndroidAutoService"
             android:exported="false"
-            android:foregroundServiceType="connectedDevice|location" />
+            android:foregroundServiceType="connectedDevice|location|microphone" />
         <meta-data
             android:name="com.google.mlkit.vision.DEPENDENCIES"
             android:value="barcode" />

--- a/app/src/main/java/dev/zanderp/opencfmoto/AndroidAutoService.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/AndroidAutoService.kt
@@ -330,26 +330,37 @@ class AndroidAutoService : Service() {
         updateNotification("Bike reconnected", hint, resume = true)
     }
 
-    private fun startAsForeground() {
-        ensureChannel()
+    fun updateForegroundType() {
         val notification = buildNotification(
             "OpenCfMoto — Android Auto",
             "Receiving Android Auto for the bike dash — tap to open",
             resume = false,
         )
-
-        // Include the location FGS type only when fine location is granted (auto-logging rides while
-        // backgrounded needs it) — declaring it without the permission would crash on Android 14+.
         val hasLocation = checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
             PackageManager.PERMISSION_GRANTED
-        var fgType = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-        if (hasLocation) fgType = fgType or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+        val hasMicrophone = checkSelfPermission(Manifest.permission.RECORD_AUDIO) ==
+            PackageManager.PERMISSION_GRANTED
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(NOTIF_ID, notification, fgType)
+            var fgType = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+            if (hasLocation) fgType = fgType or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+            if (hasMicrophone && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                fgType = fgType or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            }
+            try {
+                startForeground(NOTIF_ID, notification, fgType)
+                LogBus.log("[AA] foreground service type updated (fgType=$fgType, mic=$hasMicrophone)")
+            } catch (e: Exception) {
+                LogBus.log("[AA] failed to update foreground service type: $e")
+            }
         } else {
             startForeground(NOTIF_ID, notification)
         }
+    }
 
+    private fun startAsForeground() {
+        ensureChannel()
+        updateForegroundType()
         reacquireLocks()
         LogBus.log("[AA] foreground service up (wake + Wi-Fi locks held)")
     }
@@ -485,6 +496,10 @@ class AndroidAutoService : Service() {
          */
         fun notifyForegroundResuming() {
             active?.let { it.aaParked = false; it.wifiDownSince = 0L; it.reacquireLocks() }
+        }
+
+        fun updateForegroundType() {
+            active?.updateForegroundType()
         }
 
         const val ACTION_STOP = "dev.zanderp.opencfmoto.ACTION_STOP_AA"

--- a/app/src/main/java/dev/zanderp/opencfmoto/aa/AaMicrophone.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/aa/AaMicrophone.kt
@@ -78,6 +78,11 @@ class AaMicrophone(
             return
         }
         try {
+            dev.zanderp.opencfmoto.AndroidAutoService.updateForegroundType()
+        } catch (e: Exception) {
+            log("[MIC] failed to update service foreground type: $e")
+        }
+        try {
             preferBluetoothMic()
             val minBuf = AudioRecord.getMinBufferSize(
                 SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT


### PR DESCRIPTION
To record audio in the background on Android 14 (API 34) and above, the FOREGROUND_SERVICE_MICROPHONE permission must be declared in AndroidManifest.xml and the service must be started/updated with FOREGROUND_SERVICE_TYPE_MICROPHONE foreground service type.

This patch updates AndroidAutoService to dynamically add ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE when the microphone is started and RECORD_AUDIO permission is granted.