### PR TITLE
Fix Bluetooth permissions on Android 11

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,9 +15,19 @@
         tools:targetApi="tiramisu" />
     <uses-feature android:name="android.hardware.wifi.direct" android:required="false" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+    <!-- Android 11 and earlier -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <!-- Android 12 and later -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_CONNECT" />
     <!-- Streams the phone/helmet mic to Android Auto so the Assistant can hear you (voice
          destination entry). Optional: only used when you tap the Voice control. -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />


### PR DESCRIPTION
## Summary

Adds the legacy Bluetooth permissions required on Android 11 and earlier.

## Problem

OpenCfMoto crashes immediately when opening the setup screen on Android 11.

The Logcat output shows:

```text
Caused by: java.lang.SecurityException:
Need BLUETOOTH permission:
Neither user nor current process has android.permission.BLUETOOTH

at dev.zanderp.opencfmoto.BluetoothHelper.status(BluetoothHelper.kt:47)
at dev.zanderp.opencfmoto.SetupActivity.refreshBluetooth(SetupActivity.kt:405)
at dev.zanderp.opencfmoto.SetupActivity.onResume(SetupActivity.kt:426)
```

The application currently declares the Android 12+ Bluetooth permissions, but Android 11 still requires the legacy `BLUETOOTH` permission.

## Changes

Added the following permissions, limited to Android 11 and earlier:

```xml
<uses-permission
    android:name="android.permission.BLUETOOTH"
    android:maxSdkVersion="30" />

<uses-permission
    android:name="android.permission.BLUETOOTH_ADMIN"
    android:maxSdkVersion="30" />
```

## Testing

* Device: Samsung Galaxy A70
* Model: SM-A705FN
* Android version: Android 11
* One UI version: 3.1
* `assembleDebug` completes successfully
* The patched APK opens without the previous Bluetooth permission crash
