### PR TITLE
Fix Android Auto disconnect on Wi-Fi Direct

### DIFF
--- a/app/src/main/java/dev/zanderp/opencfmoto/AndroidAutoService.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/AndroidAutoService.kt
@@ -174,15 +174,23 @@ class AndroidAutoService : Service() {
             return
         }
         // Only park for a real Wi-Fi outage — a dash-only drop with Wi-Fi still up is the prober's job.
-        if (BikeWifi.currentNetwork == null) {
+        val apConnected = BikeWifi.currentNetwork != null
+        val p2pConnected = BikeWifiP2p.isConnected
+        if (!bikeTransportConnected(apConnected, p2pConnected)) {
             if (AppSettings.keepWifiAfterDisconnect(this)) {
                 wifiDownSince = 0L
                 return
             }
             val now = System.currentTimeMillis()
-            if (wifiDownSince == 0L) wifiDownSince = now
+            if (wifiDownSince == 0L) {
+                wifiDownSince = now
+                LogBus.log("[AA] bike transport unavailable (ap=$apConnected p2p=$p2pConnected) — starting grace")
+            }
             else if (now - wifiDownSince > GRACE_MS) parkAa()
         } else {
+            if (wifiDownSince != 0L) {
+                LogBus.log("[AA] bike transport recovered (ap=$apConnected p2p=$p2pConnected)")
+            }
             wifiDownSince = 0L
         }
     }
@@ -682,6 +690,9 @@ class AndroidAutoService : Service() {
         private const val ERROR_COOLDOWN_MS = 20_000L  // min gap between re-arm attempts after ERROR
         private const val GRACE_MS = 180_000L          // SoftAP blinks; 60s was parking mid-ride
         private const val RESUME_STEADY_TIMEOUT_MS = 12_000L // wait for AA video before falling back
+
+        internal fun bikeTransportConnected(apConnected: Boolean, p2pConnected: Boolean): Boolean =
+            apConnected || p2pConnected
 
         /** Intent extra: MainActivity should re-project on open (BAL-safe resume after a park). */
         const val EXTRA_RESUME = "dev.zanderp.opencfmoto.RESUME_PROJECTION"

--- a/app/src/main/java/dev/zanderp/opencfmoto/BikeWifiP2p.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/BikeWifiP2p.kt
@@ -59,6 +59,9 @@ object BikeWifiP2p {
     @Volatile private var connectIssued = false
     @Volatile private var timeoutThread: Thread? = null
 
+    /** True only while Android reports an active Wi-Fi Direct group. */
+    val isConnected: Boolean get() = active && connected
+
     /**
      * @param onConnected called with (phoneBindIp, bikeGatewayIp) once the group is formed and
      *   both addresses are known. Pass these straight to [EasyConnProber.start].
@@ -279,7 +282,12 @@ object BikeWifiP2p {
                         mgr.requestConnectionInfo(chan) { info ->
                             log("$TAG conn: groupFormed=${info.groupFormed} isGO=${info.isGroupOwner} " +
                                 "goAddr=${info.groupOwnerAddress?.hostAddress}")
-                            if (info.groupFormed && !connected) onGroupFormed(mgr, chan, info, onConnected, onFailed, log)
+                            if (info.groupFormed && !connected) {
+                                onGroupFormed(mgr, chan, info, onConnected, onFailed, log)
+                            } else if (!info.groupFormed && connected) {
+                                connected = false
+                                log("$TAG group lost")
+                            }
                         }
                     }
                 }
@@ -474,4 +482,3 @@ object BikeWifiP2p {
         }
     }
 }
-

--- a/app/src/test/java/dev/zanderp/opencfmoto/AndroidAutoServiceTest.kt
+++ b/app/src/test/java/dev/zanderp/opencfmoto/AndroidAutoServiceTest.kt
@@ -1,0 +1,15 @@
+package dev.zanderp.opencfmoto
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidAutoServiceTest {
+    @Test
+    fun bikeTransportIsLiveForApOrP2p() {
+        assertFalse(AndroidAutoService.bikeTransportConnected(false, false))
+        assertTrue(AndroidAutoService.bikeTransportConnected(true, false))
+        assertTrue(AndroidAutoService.bikeTransportConnected(false, true))
+        assertTrue(AndroidAutoService.bikeTransportConnected(true, true))
+    }
+}


### PR DESCRIPTION
## What changed

- Treat an active Wi-Fi Direct group as a live bike transport in the Android Auto reconnect supervisor.
- Clear the P2P liveness flag when Android reports that the group has been lost.
- Add a unit test covering AP, P2P, both, and neither transport.

## Root cause

CFDL26 / CFMOTO 1000MT-X sessions use Wi-Fi Direct and intentionally do not expose a
`ConnectivityManager.Network` through `BikeWifi.currentNetwork`. After streaming started,
the reconnect supervisor interpreted that null AP network as a Wi-Fi outage and eventually
parked Android Auto while the P2P group remained connected.

The supervisor now considers the actual transport in use: AP or P2P. A genuine loss of both
transports keeps current `main`'s 180-second grace period and
`keep Wi-Fi after disconnect` behaviour.

## Validation

- Rebased onto `main` at `6f51168`.
- Physical test on 2026-08-25: CFMOTO 1000MT-X + Nothing Phone 2; the build using this fix
  no longer disconnected during the test session.
- `./gradlew --no-daemon testDebugUnitTest --tests dev.zanderp.opencfmoto.AndroidAutoServiceTest` — passes.
- `./gradlew --no-daemon assembleDebug` — passes.
- Full local unit suite: 79/81 pass; the two failures are locale-dependent
  `GpxNavTest` expectations outside this diff.
- `lintDebug` reports the existing project backlog (207 errors, 456 warnings); the first
  error is `MissingPermission` in `AaMicrophone.kt`, outside this diff.
