### PR TITLE
feat: remember the working Wi-Fi transport per bike (skip the dead P2P wait)

### DIFF
--- a/app/src/main/java/dev/zanderp/opencfmoto/BikeMemory.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/BikeMemory.kt
@@ -31,6 +31,9 @@ object BikeMemory {
     private const val KEY_RAW = "last_qr_raw"
     private const val KEY_NAME = "last_bike_name"
 
+    // Per-bike winning Wi-Fi transport ("AP" | "P2P"), keyed by the (stable) dash SSID.
+    private const val KEY_TRANSPORT_PREFIX = "transport_"
+
     private fun prefs(ctx: Context) =
         ctx.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
@@ -100,6 +103,24 @@ object BikeMemory {
             .remove(KEY_LIST).remove(KEY_SELECTED)
             .remove(KEY_RAW).remove(KEY_NAME)
             .apply()
+    }
+
+    /**
+     * The Wi-Fi transport ("AP" | "P2P") that last produced a live link for [ssid], or null if we've
+     * never connected this bike. Lets the connect path skip the transport that doesn't work on this
+     * phone instead of burning its timeout every time (see [setWinningTransport]).
+     */
+    fun winningTransport(ctx: Context, ssid: String): String? =
+        if (ssid.isBlank()) null else prefs(ctx).getString("$KEY_TRANSPORT_PREFIX$ssid", null)
+
+    /**
+     * Remember which transport just got Wi-Fi up for this bike. Some dashes advertise Wi-Fi Direct
+     * (DIRECT-* SSID) yet never form a P2P group on a given phone; the app then falls back to the
+     * SoftAP after a long timeout. Recording the winner makes every later connect go straight to it.
+     */
+    fun setWinningTransport(ctx: Context, ssid: String, transport: String) {
+        if (ssid.isBlank()) return
+        prefs(ctx).edit().putString("$KEY_TRANSPORT_PREFIX$ssid", transport).apply()
     }
 
     // ---- convenience accessors used across the app (selected bike) ----

--- a/app/src/main/java/dev/zanderp/opencfmoto/BikeWifiP2p.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/BikeWifiP2p.kt
@@ -44,8 +44,9 @@ import kotlin.math.abs
 object BikeWifiP2p {
 
     private const val TAG = "[P2P]"
-    /** Longer window for non-DIRECT-* MAC joins (Zontes / crowded peer lists). */
-    private const val CONNECT_TIMEOUT_MS = 40_000L
+    /** Default window for non-DIRECT-* MAC joins (Zontes / crowded peer lists). Callers can pass a
+     *  shorter [connect] timeout when a SoftAP fallback exists (see [MainActivity]). */
+    const val CONNECT_TIMEOUT_MS = 40_000L
     private const val IP_POLL_TIMEOUT_MS = 10_000L
     private const val IP_POLL_INTERVAL_MS = 500L
 
@@ -69,6 +70,10 @@ object BikeWifiP2p {
         onConnected: (bindIp: Inet4Address, gatewayIp: Inet4Address) -> Unit,
         onFailed: (reason: String) -> Unit,
         log: (String) -> Unit,
+        // How long to wait for a P2P group before failing over. When the QR also advertises a SoftAP
+        // (a proven fallback), the caller passes a short value so a phone that can't form a P2P group
+        // fails over in seconds instead of burning the full window. Default keeps prior behaviour.
+        timeoutMs: Long = CONNECT_TIMEOUT_MS,
     ) {
         stop(log) // clean any prior attempt
         active = true
@@ -108,7 +113,7 @@ object BikeWifiP2p {
             attemptMacJoin(mgr, chan, qr, log)
         }
 
-        startTimeout(onFailed, log)
+        startTimeout(onFailed, log, timeoutMs)
     }
 
     @SuppressLint("MissingPermission")
@@ -376,12 +381,12 @@ object BikeWifiP2p {
         return null
     }
 
-    private fun startTimeout(onFailed: (String) -> Unit, log: (String) -> Unit) {
+    private fun startTimeout(onFailed: (String) -> Unit, log: (String) -> Unit, timeoutMs: Long) {
         cancelTimeout()
         timeoutThread = thread(name = "p2p-timeout", isDaemon = true) {
-            try { Thread.sleep(CONNECT_TIMEOUT_MS) } catch (_: InterruptedException) { return@thread }
+            try { Thread.sleep(timeoutMs) } catch (_: InterruptedException) { return@thread }
             if (active && !connected) {
-                fail(onFailed, log, "no P2P group formed within ${CONNECT_TIMEOUT_MS / 1000}s")
+                fail(onFailed, log, "no P2P group formed within ${timeoutMs / 1000}s")
             }
         }
     }

--- a/app/src/main/java/dev/zanderp/opencfmoto/MainActivity.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/MainActivity.kt
@@ -1004,13 +1004,26 @@ class MainActivity : AppCompatActivity() {
                     (qr.ssid.startsWith("DIRECT-", ignoreCase = true) &&
                         (qr.supportsP2p || !qr.supportsAp))
         }
+        // Per-bike memory refines AUTO only (an explicit P2P/AP setting is the rider's call): once a
+        // transport has produced a live link for THIS bike, use it and skip the dead path. Some dashes
+        // advertise DIRECT-* + SoftAP, so AUTO tries P2P first and burns the whole timeout on every
+        // connect even when P2P never forms a group on this phone, while SoftAP connects in seconds.
+        val remembered = if (transport == WifiTransport.AUTO) BikeMemory.winningTransport(this, qr.ssid) else null
+        val effUseP2p = when {
+            remembered == "AP" && qr.supportsAp -> false
+            remembered == "P2P" && qr.supportsP2p -> true
+            else -> useP2p
+        }
+        if (remembered != null && effUseP2p != useP2p) {
+            log("→ transport memory: '$remembered' connected before for '${qr.ssid}' — using it, skipping the dead path")
+        }
         if (transport == WifiTransport.P2P && !useP2p) {
             log(
                 "→ Setup Wi‑Fi transport is P2P but QR is SoftAP-only " +
                     "(action=${qr.action} ssid=${qr.ssid}) — joining SoftAP instead",
             )
         }
-        if (useP2p) {
+        if (effUseP2p) {
             val isDirect = qr.ssid.startsWith("DIRECT-", ignoreCase = true)
             // P2P-only QRs with a SoftAP-style SSID but no MAC burn ~40s on MAC ERROR
             // (Voge-5G / ZT5G / etc.). Prefer SoftAP immediately when we have a password.
@@ -1036,6 +1049,8 @@ class MainActivity : AppCompatActivity() {
             psk = qr.pwd,
             onAvailable = { network ->
                 WifiGate.cancelNotification(applicationContext)
+                // SoftAP got Wi-Fi up for this bike → remember it so AUTO skips P2P next time.
+                BikeMemory.setWinningTransport(applicationContext, qr.ssid, "AP")
                 if (gateOnAaSteady) {
                     LogBus.log("→ bike Wi-Fi bound (waiting for AA video to go steady)")
                     BikeLink.markWifiReady(network)
@@ -1183,11 +1198,25 @@ class MainActivity : AppCompatActivity() {
     private fun joinWifiP2p(qr: QrData, gateOnAaSteady: Boolean) {
         if (!WifiGate.ensureEnabledOrPrompt(this)) return
         LogBus.log("→ joining via Wi‑Fi Direct (P2P)")
+        // How long to wait for a P2P group before failing over to SoftAP:
+        //  - "P2P" remembered  → proven P2P device on this phone; give it the full window.
+        //  - SoftAP advertised → a working fallback exists, so bail fast (6s) when P2P is hopeless
+        //    (some phones ERROR on every join attempt in <1s but the group never forms).
+        //  - otherwise (P2P-only) → full window; there is nothing to fall back to.
+        val known = BikeMemory.winningTransport(this, qr.ssid)
+        val p2pTimeout = when {
+            known == "P2P" -> BikeWifiP2p.CONNECT_TIMEOUT_MS
+            qr.supportsAp && qr.pwd.isNotEmpty() -> 6_000L
+            else -> BikeWifiP2p.CONNECT_TIMEOUT_MS
+        }
         BikeWifiP2p.connect(
             context = applicationContext,
             qr = qr,
+            timeoutMs = p2pTimeout,
             onConnected = { bindIp, gatewayIp ->
                 WifiGate.cancelNotification(applicationContext)
+                // P2P actually formed a group for this bike → remember it (some DIRECT-* bikes need P2P).
+                BikeMemory.setWinningTransport(applicationContext, qr.ssid, "P2P")
                 if (gateOnAaSteady) {
                     LogBus.log("→ P2P bound (waiting for AA video); bike=${gatewayIp.hostAddress}")
                     BikeLink.markP2pReady(bindIp, gatewayIp)
@@ -1219,6 +1248,8 @@ class MainActivity : AppCompatActivity() {
                     psk = qr.pwd,
                     onAvailable = { network ->
                         WifiGate.cancelNotification(applicationContext)
+                        // SoftAP fallback connected → remember AP so AUTO goes straight here next time.
+                        BikeMemory.setWinningTransport(applicationContext, qr.ssid, "AP")
                         if (gateOnAaSteady) BikeLink.markWifiReady(network)
                         else {
                             ConnectionState.set(Phase.PXC_CONNECTING)


### PR DESCRIPTION
Small connect-time quality-of-life fix, found riding a CFMoto 450NK whose dash advertises Wi-Fi Direct (`DIRECT-go-CFMOTO-…`) but never forms a P2P group on my phone.

**Problem.** In AUTO, a `DIRECT-*` SSID makes the app try Wi-Fi Direct first. On a phone where P2P never forms a group, it waits out the full timeout before falling back to the SoftAP — which connects in a couple of seconds — on *every* connect. Measured on-device: the P2P join requests `ERROR` almost immediately, then the app sits idle for the whole window before the SoftAP fallback that actually links up.

**Fix.** Remember, per bike SSID, which transport last got Wi-Fi up, and in AUTO go straight to it next time. After the first connect the app never pays the dead-path wait again — reconnects are effectively instant. To also bound the *first* connect, P2P now fails over to the SoftAP in 6s when the QR advertises a SoftAP fallback.

It's self-correcting and per-phone:

- a bike that genuinely needs P2P records `"P2P"` on its first success and always gets the **full** window (a slow-but-real group is never cut short);
- a bike that only works over SoftAP records `"AP"` and skips P2P thereafter;
- a P2P-only QR (no SoftAP to fall back to) keeps the full window.

Memory only refines **AUTO** — an explicit Setup → transport choice is left untouched, and bikes whose P2P already works see no behavior change.

**Scope** (3 files, +64/−7):
- `BikeMemory` — `winningTransport` / `setWinningTransport`, keyed by the dash SSID.
- `BikeWifiP2p.connect(timeoutMs = …)` — parameterize the P2P failover window (default unchanged).
- `MainActivity` — consult memory in AUTO; record the winner on each successful Wi-Fi bring-up.

Tested on the 450NK: first connect learns `"AP"`, and every subsequent connect skips straight past the P2P wait.
