### PR TITLE
feat: handlebar ▲/▼ volume toggle

### DIFF
--- a/app/src/main/java/dev/zanderp/opencfmoto/ControlsActivity.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/ControlsActivity.kt
@@ -131,6 +131,14 @@ class ControlsActivity : AppCompatActivity() {
             if (checked) ensureMicPermission()
         }
 
+        // ▲/▼ = navigate the AA menu (default) vs. plain volume. Live-applied via the pref setter.
+        val swVol = findViewById<MaterialSwitch>(R.id.switch_handlebar_volume_nav)
+        swVol.isChecked = HandlebarVolumeMode.isNavigate(this)
+        swVol.setOnCheckedChangeListener { _, checked ->
+            HandlebarVolumeMode.set(this, checked)
+            LogBus.log("→ handlebar ▲/▼ ${if (checked) "navigate the AA menu" else "control volume"}")
+        }
+
         findViewById<MaterialButton>(R.id.btn_customize).setOnClickListener {
             startActivity(Intent(this, ButtonMappingActivity::class.java))
         }

--- a/app/src/main/java/dev/zanderp/opencfmoto/HandlebarVolumeMode.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/HandlebarVolumeMode.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Part of OpenCfMoto. Free software under the GNU AGPL v3 or later; see LICENSE and NOTICE.
+package dev.zanderp.opencfmoto
+
+import android.content.Context
+
+/**
+ * What the bike's ▲/▼ volume rocker does while projecting:
+ *   true  (default) = NAVIGATE — [MediaButtonBridge] pins the music stream and reads the rocker's
+ *                     direction as Android Auto UI navigation (previous/next). Volume is then set
+ *                     elsewhere (phone buttons / the Controls slider).
+ *   false           = VOLUME — the rocker changes the phone's volume normally; nothing is pinned and
+ *                     no navigation is fired. Use this if you'd rather control volume from the bike.
+ *
+ * Split from [ButtonMode] (which governs the track/select keys) because a rider may want the track
+ * keys on AA navigation while ▲/▼ still work as plain volume. Per-bike via [BikeScope].
+ */
+object HandlebarVolumeMode {
+    private const val PREF = "handlebar_volume_mode"
+    private const val KEY = "navigate"
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+
+    /** True = ▲/▼ navigate the AA UI (pins volume). False (default) = ▲/▼ are plain volume. */
+    fun isNavigate(context: Context): Boolean =
+        BikeScope.getBoolean(prefs(context), context, KEY, false)
+
+    fun set(context: Context, navigate: Boolean) {
+        BikeScope.putBoolean(prefs(context), context, KEY, navigate)
+        // Apply live if the bridge is running.
+        MediaButtonBridge.instance?.refreshVolumePresencePolicy()
+    }
+}

--- a/app/src/main/java/dev/zanderp/opencfmoto/MediaButtonBridge.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/MediaButtonBridge.kt
@@ -466,6 +466,15 @@ class MediaButtonBridge(private val context: Context, private val log: (String) 
      * never sends ▲/▼ must not hold STREAM_MUSIC hostage.
      */
     private fun maybePinVolume(reason: String) {
+        // ▲/▼ set to Volume mode: never pin — the rocker must move the phone volume normally, and with
+        // nothing pinned the volume observer fires no navigation (it early-returns on pinnedVolume<0).
+        if (!HandlebarVolumeMode.isNavigate(context)) {
+            if (pinnedVolume >= 0) {
+                log("[BTN] skip pin ($reason) — ▲/▼ set to Volume; unpinning so volume works normally")
+                unpinVolume()
+            }
+            return
+        }
         if (!ButtonPresencePrefs.shouldPinVolume(context)) {
             if (pinnedVolume >= 0) {
                 log("[BTN] skip pin ($reason) — volume rocker ABSENT; unpinning")

--- a/app/src/main/res/layout/activity_controls.xml
+++ b/app/src/main/res/layout/activity_controls.xml
@@ -457,6 +457,23 @@
                     android:textColor="@color/text_secondary"
                     android:textSize="13sp" />
 
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/switch_handlebar_volume_nav"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/controls_updown_navigate"
+                    android:textColor="@color/text_primary"
+                    android:textSize="15sp" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/controls_updown_navigate_desc"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="13sp" />
+
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/btn_customize"
                     style="@style/Widget.OpenCfMoto.Segment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,8 @@
     <string name="controls_handlebar_buttons">Handlebar buttons</string>
     <string name="controls_your_dash_is_a_touchscreen_just_tap_the_screen_t">Your dash is a touchscreen — just tap the screen to navigate. Handlebar-button control is meant for non-touch dashes (e.g. 450SR); on this bike it can\'t move the menu and only pauses your music.</string>
     <string name="controls_handlebar_buttons_drive_android_auto">Handlebar buttons drive Android Auto</string>
+    <string name="controls_updown_navigate">▲/▼ navigate the Android Auto menu</string>
+    <string name="controls_updown_navigate_desc">On: the ▲/▼ rocker moves the Android Auto menu (volume is set from the phone or the slider above). Off: ▲/▼ change the volume normally.</string>
     <string name="controls_requires_the_phone_paired_to_the_bike_over_bluet">Requires the phone paired to the bike over Bluetooth.\n\nWhile on, the bars drive the Android Auto UI (not track-skip). Music can keep playing — start/stop/skip by navigating that UI with the bars or the on-screen pad. Turn OFF only if you want the physical bars to control media again.</string>
     <string name="controls_customize_buttons">Customize buttons</string>
     <string name="res_match_panel_aspect">Match panel aspect</string>


### PR DESCRIPTION
Handlebar ▲/▼ as a volume control. A Setup toggle picks whether the bar's up/down keys navigate the AA map or change media volume; in volume mode `MediaButtonBridge` stops pinning `STREAM_MUSIC` so the rider can raise/lower it from the bars (and from the dash) without the two fighting.

Rebased on current `main`. The on-phone AA audio groundwork that was previously bundled here now lives in its own draft — #27 — as you asked.
