### PR TITLE
fix(aa): dial out to Android Auto's head unit server on AA 17.4+

### DIFF
--- a/app/src/main/java/dev/zanderp/opencfmoto/aa/AaReceiver.kt
+++ b/app/src/main/java/dev/zanderp/opencfmoto/aa/AaReceiver.kt
@@ -7,12 +7,14 @@
 package dev.zanderp.opencfmoto.aa
 
 import android.content.Context
+import android.net.ConnectivityManager
 import dev.zanderp.opencfmoto.AaVideoBridge
 import dev.zanderp.opencfmoto.BikeWifi
 import dev.zanderp.opencfmoto.NightPrefs
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.view.Surface
+import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.net.Socket
 import kotlin.concurrent.thread
@@ -24,16 +26,38 @@ class AaReceiver(
 ) {
     companion object {
         const val PORT = 5288
+
+        /**
+         * Android Auto's own head unit server — the port the Desktop Head Unit talks to over
+         * adb forward. AA 17.4 ships WirelessStartupReceiver with android:enabled="false" and the
+         * activity it forwards to is not exported, so every AaSelfMode poke is swallowed silently:
+         * result=0, no log, no error. This port is the path Google left open — the rider starts
+         * it once from Android Auto's developer settings and gearhead listens here.
+         */
+        const val HEADUNIT_SERVER_PORT = 5277
+
+        /** Let the three AaSelfMode pokes (~3.6 s of escalation) play out before dialling out. */
+        private const val FIRST_DIAL_DELAY_MS = 4_000L
+        private const val DIAL_INTERVAL_MS = 2_000L
+        private const val DIAL_ATTEMPTS = 20
+        private const val DIAL_TIMEOUT_MS = 800
     }
 
     @Volatile private var running = false
     private var serverSocket: ServerSocket? = null
     private var acceptThread: Thread? = null
+    private var dialThread: Thread? = null
     private var nsdManager: NsdManager? = null
     private var registrationListener: NsdManager.RegistrationListener? = null
 
     @Volatile private var transport: AapTransport? = null
     @Volatile private var connection: SocketAccessoryConnection? = null
+    /**
+     * Held between claiming the session slot and [transport] going live, so an inbound accept and
+     * the head-unit-server dial-out can never both start a session.
+     */
+    @Volatile private var sessionStarting = false
+    private val sessionLock = Any()
     @Volatile private var steadyVideoFired = false
 
     /**
@@ -95,6 +119,10 @@ class AaReceiver(
         acceptThread = thread(name = "aa-accept", isDaemon = true) { acceptLoop() }
         // Self-mode (launching Google Android Auto) is triggered by MainActivity from the
         // foreground, via AaSelfMode.trigger(), to satisfy background-activity-launch rules.
+        // Those pokes never land on AA 17.4+, so we also dial OUT to gearhead's head unit server.
+        dialThread = thread(name = "aa-dial-hu", isDaemon = true) {
+            try { dialHeadunitServerLoop() } catch (_: InterruptedException) {}
+        }
     }
 
     /**
@@ -135,6 +163,8 @@ class AaReceiver(
         try { serverSocket?.close() } catch (_: Exception) {}
         serverSocket = null
         acceptThread?.interrupt(); acceptThread = null
+        dialThread?.interrupt(); dialThread = null
+        releaseSession()
         AaLog.sink = null
         log("[AA] receiver stopped")
     }
@@ -149,7 +179,7 @@ class AaReceiver(
                 break
             }
             log("[AA] <<< Android Auto connected from ${client.inetAddress?.hostAddress}")
-            if (transport != null) {
+            if (!claimSession()) {
                 log("[AA] already have a session — dropping extra connection")
                 try { client.close() } catch (_: Exception) {}
                 continue
@@ -174,6 +204,7 @@ class AaReceiver(
             AaVideoBridge.nightSink = null
             try { t.microphone?.stop("transport quit") } catch (_: Exception) {}
             transport = null
+            releaseSession()
             try { conn.disconnect() } catch (_: Exception) {}
             connection = null
             // Server keeps listening — AA (or the user) can reconnect. On a genuine user Exit we
@@ -224,6 +255,7 @@ class AaReceiver(
         if (!t.startHandshake(conn)) {
             log("[AA] handshake FAILED")
             transport = null
+            releaseSession()
             try { conn.disconnect() } catch (_: Exception) {}
             connection = null
             return
@@ -232,6 +264,74 @@ class AaReceiver(
         videoDecoder.setSurface(encoderSurface)
         t.startReading()
         log("[AA] read loop started — expecting ServiceDiscovery then video")
+    }
+
+    /** Claim the single session slot; false when one is live or another path got there first. */
+    private fun claimSession(): Boolean = synchronized(sessionLock) {
+        if (sessionStarting || transport != null) false else { sessionStarting = true; true }
+    }
+
+    private fun releaseSession() = synchronized(sessionLock) { sessionStarting = false }
+
+    /**
+     * AA 17.4+ fallback: connect OUT to Android Auto's head unit server instead of waiting for
+     * gearhead to connect IN. The AAP roles do not change — we are still the head unit, exactly
+     * as on an inbound :5288 socket — only the TCP direction flips, so [handleConnection] runs
+     * unmodified. Needs the rider to have started the server from Android Auto's developer settings
+     * (tap Version 10x, then the overflow menu).
+     */
+    private fun dialHeadunitServerLoop() {
+        Thread.sleep(FIRST_DIAL_DELAY_MS)
+        var attempt = 0
+        while (running && attempt < DIAL_ATTEMPTS) {
+            attempt++
+            if (transport != null || sessionStarting) return
+            val sock = try {
+                connectLoopback(HEADUNIT_SERVER_PORT)
+            } catch (e: Exception) {
+                if (attempt == 1 || attempt % 5 == 0) {
+                    log(
+                        "[AA] head unit server :$HEADUNIT_SERVER_PORT no answer " +
+                            "(try $attempt/$DIAL_ATTEMPTS) — ${e.javaClass.simpleName}: ${e.message}",
+                    )
+                }
+                null
+            }
+            if (sock != null) {
+                if (!claimSession()) {
+                    try { sock.close() } catch (_: Exception) {}
+                    return
+                }
+                log("[AA] >>> dialled OUT to Android Auto head unit server :$HEADUNIT_SERVER_PORT (AA 17.4 path)")
+                thread(name = "aa-session", isDaemon = true) { handleConnection(sock) }
+                return
+            }
+            Thread.sleep(DIAL_INTERVAL_MS)
+        }
+        if (running && transport == null) {
+            log(
+                "[AA] head unit server never answered on :$HEADUNIT_SERVER_PORT — in Android Auto " +
+                    "tap Version 10x, then overflow menu → Start head unit server",
+            )
+        }
+    }
+
+    /**
+     * Loopback connect that survives the bike Wi-Fi bind. While the process is bound to the bike
+     * [android.net.Network] there is no route to 127.0.0.1 — the same ENONET [start] already
+     * works around for the ServerSocket. Drop the bind for the few ms the connect takes, then
+     * restore the exact same Network. Established sockets ignore the process bind, so the bike link
+     * never notices.
+     */
+    private fun connectLoopback(port: Int): Socket {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        val bound = try { cm?.boundNetworkForProcess } catch (_: Exception) { null }
+        try {
+            if (bound != null) try { cm?.bindProcessToNetwork(null) } catch (_: Exception) {}
+            return Socket().apply { connect(InetSocketAddress("127.0.0.1", port), DIAL_TIMEOUT_MS) }
+        } finally {
+            if (bound != null) try { cm?.bindProcessToNetwork(bound) } catch (_: Exception) {}
+        }
     }
 
     private fun registerNsd() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -501,7 +501,7 @@
     <string name="conn_detail_connect_failed">Connect failed — see Logs / Share Logs</string>
     <string name="conn_detail_auto_connect_failed">Auto-connect failed — see Logs</string>
     <string name="conn_detail_need_bluetooth">Grant Nearby devices / Bluetooth, then tap Connect again</string>
-    <string name="conn_detail_aa_not_started">Android Auto didn\'t attach — open the Android Auto app once. If you\'re on AA 17.4 beta: Settings → Apps → Android Auto → Uninstall updates, then retry Connect. SoftAP/Mirror still prove the bike Wi‑Fi link.</string>
+    <string name="conn_detail_aa_not_started">Android Auto didn\'t attach. On Android Auto 17.4+ Google blocked the automatic start: open Android Auto, tap Version 10 times, then ⋮ → Start head unit server, and retry Connect. SoftAP/Mirror still prove the bike Wi‑Fi link.</string>
     <string name="main_aa_need_nearby_title">Nearby devices required</string>
     <string name="main_aa_need_nearby_message">Android Auto Connect needs Nearby devices (Bluetooth) so the phone can start wireless projection. Grant Nearby, turn Bluetooth on, then tap Connect again.\n\nMirror and Map do not need this.</string>
     <string name="main_aa_need_bt_on_message">Turn Bluetooth on, then tap Connect again. Android Auto Connect uses Bluetooth to start wireless projection on newer Android Auto builds.\n\nMirror and Map do not need this.</string>


### PR DESCRIPTION
Android Auto 17.4 ships WirelessStartupReceiver with android:enabled="false",
and the activity it forwards to is not exported. Every AaSelfMode poke is
swallowed, gearhead never dials into :5288, and Connect ends on
conn_detail_aa_not_started. Escalating harder cannot fix it: all three paths go
through doors Google closed.

Confirmed on a Samsung SM-S936B (Android 16, SDK 36) with gearhead
17.4.663034-release, against a CFMoto 800MT Explorer 2025:

    [AA] WirelessServer listening on :5288
    [AA] gearhead versionName=17.4.663034-release versionCode=174663034
    [AA] Activity trigger failed (Permission Denial ... not exported from uid 10260)
    [AA] broadcast fallback sent
    [AA] SelfMode BT: bonded=11 selected=53:8F:4A:xx:xx:xx name=CFMOTO_BT
    [AA] broadcast fallback 2 (START_WIRELESS_PROJECTION mac=53:8F:4A:xx:xx:xx) sent
    [AA] Android Auto never attached

Path 3 was sent with a correctly resolved bike MAC, so this is not the "no real
BT MAC" case — gearhead simply ignores all three.

Flip the TCP direction instead. Android Auto's own head unit server (the port
the Desktop Head Unit talks to over adb forward) still works on 17.4: the rider
starts it from Android Auto's developer settings, gearhead listens on
127.0.0.1:5277, and AaReceiver connects out. The AAP roles do not change — we
are still the head unit, exactly as on an inbound :5288 socket — so
handleConnection() runs unmodified: same version + SSL handshake, same video,
input, mic and night-mode wiring. AapSslContext already builds its engine for
("android-auto", 5277).

- AaReceiver dials :5277 4 s after start (letting the three existing pokes play
  out first), then every 2 s for 20 tries, and gives up with a log line naming
  the setting to enable. The inbound path is untouched, so nothing changes for
  riders on gearhead versions where the pokes still land.
- connectLoopback() drops the bike Network process bind for the few ms the
  connect takes and restores the exact same Network afterwards. A process bound
  to the bike Wi-Fi has no route to 127.0.0.1 — the same ENONET start() already
  works around for the ServerSocket. Established sockets ignore the process
  bind, so the bike link is not disturbed.
- claimSession()/releaseSession() guard the single session slot, so the inbound
  accept and the dial-out can never both start a session.
- conn_detail_aa_not_started now points at the head unit server. The old text
  told riders to uninstall Android Auto updates, which on Samsung reverts
  gearhead to the 1.2.x stub and leaves them with no Android Auto at all
  (observed: versionName=1.2.558700-stub, then "Unable to find explicit activity
  class").

Same log, after the change — the three pokes still run and are still ignored,
and the dial-out is what connects:

    23:46:37.149  [AA] WirelessServer listening on :5288
    23:46:37.933  [AA] Activity trigger failed (Permission Denial ... not exported)
    23:46:37.942  [AA] broadcast fallback sent
    23:46:39.160  [AA] broadcast fallback 2 (START_WIRELESS_PROJECTION ...) sent
    23:46:41.155  [AA] >>> dialled OUT to Android Auto head unit server :5277 (AA 17.4 path)
    23:46:41.281  [AA] SSL handshake complete.
    23:46:41.281  [AA] handshake OK — pointing decoder at encoder surface
    23:46:44.644  [AA] steady video reached (fps=29) — signalling ready for bike hand-off

3.5 s from dial-out to steady video, then ~5.5 minutes of Android Auto on the
dash at 29-30 fps with Maps navigating. The one link drop in that window was the
dash closing the PXC control socket after QUERY_SPEED; it re-probed and
recovered on attempt 1, and the bike probe went straight back out over
Network.socketFactory — unrelated to this path, and evidence the rebind in
connectLoopback() restores the bind cleanly.

Known limitation: the rider has to start the head unit server from Android
Auto's developer settings. I did not find an exported way to start it
programmatically; if someone knows one, it would turn this into a one-time
setup step instead of a per-ride one.
