### PR TITLE
docs: RE notes — vehicle telemetry (fuel/RPM/…) isn't reachable without a T-Box

### DIFF
--- a/docs/RE-VEHICLE-TELEMETRY.md
+++ b/docs/RE-VEHICLE-TELEMETRY.md
@@ -1,0 +1,85 @@
+# RE notes: vehicle telemetry (fuel/RPM/…) is not reachable without a T-Box
+
+> Field notes from mapping whether a **CFMoto 450NK (2027), no T-Box** exposes any live vehicle
+> data (fuel, RPM, gear, temps) to the phone. Short answer: **no** — not over BLE, not over PXC, not
+> over the dash's Wi-Fi Direct network. Method follows §8 of `01-REVERSE-ENGINEERING.md`: best-effort
+> read-only probes shipped in a debug build, run against a live projecting bike with verbose logging.
+> Bike-specific identifiers (HUID, SN, VIN, MAC, OTA password) are redacted; only mechanism is shared.
+
+## Why this might interest the project
+
+- It **corrects one line in §6**: the BLE the bike advertises is not (only) "vehicle control
+  (lock/telemetry)" — on this unit it's an **audio module**, and it carries no telemetry (details
+  below). There's also an **undocumented GATT service** the wake-up path is blind to.
+- It closes the "can we read vehicle data?" question with evidence, so nobody re-runs it hoping.
+
+## 1. BLE — an audio module, and an undocumented service
+
+A read-only GATT survey next to the powered-on bike found it advertising as `CFMOTO-LE-XXXXXX`
+(RSSI −55) with an **undocumented service** alongside the known wake-up one:
+
+```
+service 0000b360-d6d8-c7ec-bdf0-eab1bfc6bcbc
+  char  0000b362-...   props = WRITE | WRITE_NR | NOTIFY
+Device Information (0x180A):
+  Manufacturer = "Feasycom"   Model = "FSC-BT1026C"   FW = V6.4.2
+```
+
+- Same vendor suffix (`…-d6d8-c7ec-bdf0-eab1bfc6bcbc`) as the wake-up service `b354`, but a **different
+  service** (`b360`). `BleWakeUp` matches the bike by name and then looks only for `b354`, so it never
+  sees `b360` — worth noting if anyone extends the BLE path.
+- The **FSC-BT1026 is a dual-mode BT audio module** (stereo codec, I2S, transparent-UART bridge). So
+  `b362` is a serial bridge to the dash's audio MCU — the hands-free / media-button path — not a
+  telemetry channel. Consistent with the bike's `CLIENT_INFO` (`supportBTCall:true`, `btPin`,
+  `bluetoothPolicy:2`).
+- **Subscribed to the NOTIFY char for two full 60 s windows while revving the engine and toggling
+  lights: zero notifications.** The dash pushes nothing on its own here.
+
+## 2. PXC / projection plane — screen and touch only
+
+With unknown control frames hex-dumped during a live session, the only non-standard frame
+(`0x10470` → ack `0x10471`) was the **voice-command grammar** (Chinese regex for music control,
+`"cnt":9`). `RVINFO (0x60004110)` is a screen event (`sendRvInfo(ECPAppScreenEvent*)` in
+`librvserver.so`), not vehicle info. The AA SENSOR channel only ever starts `DRIVING_STATUS` + `NIGHT`.
+
+## 3. The dash's own network — swept wide, closed
+
+During projection the dash is `192.168.49.1`. Read-only sweep from the phone:
+
+- **Full TCP scan 1–65535: 0 open** (only `10930`, the PXC probe port, and only transiently).
+- **UDP probes: no response.**
+- **Passive listen (25 s) for any broadcast/multicast the dash emits: nothing** — only the phone's
+  own mDNS. The dash advertises **no** mDNS services.
+
+## 4. The OTA SOCKS — the dash asks the phone to be its uplink, but never dials out
+
+During projection the dash sends `SOCK_SERVER_INFO (0x104a0)`:
+
+```
+{ "ctrlPort": 11026, "dataPort": 11025, "userName": "carbit_ota_user", "pwd": "<redacted>" }
+```
+
+This is **not** a proxy *into* the dash — a connect to `11026` on the dash side is refused. It's the
+dash asking **the phone** to run a SOCKS5 server it can dial out through to reach CFMoto's cloud
+(OTA), since a T-Box-less dash has no internet of its own. Standing up that SOCKS5 server on the phone
+(observe-and-forward, over a cellular uplink) and waiting through a full projection session: **the
+dash advertised the proxy but never connected to it.** It seems to only phone home on a schedule /
+at boot / when the official app triggers it — not during a normal ride.
+
+## Conclusion
+
+Across BLE, PXC, the dash network, and the OTA path, **no live vehicle data reaches the phone without
+a T-Box.** CFMoto gates telemetry behind the T-Box (a paid 4G module) by design. The dash *has* the
+data — it renders it — but serves it on none of these surfaces.
+
+The remaining path with the data guaranteed is the **CAN bus** at the diagnostic connector (a
+commercial scanner reads live engine/cluster data there). On a Euro5 bike, standard OBD-II PIDs via a
+cheap ELM327 are worth trying before raw-CAN sniffing.
+
+*One untried free lever: power-cycle the dash while the phone is projecting with the SOCKS server up —
+if its OTA check runs at boot, it would dial out through us then.*
+
+---
+
+*If any of this is useful in the docs, happy to adapt it into `01-REVERSE-ENGINEERING.md` §6/§8
+directly — kept it as a standalone note to avoid presuming edits to your canonical file.*


### PR DESCRIPTION
Field notes from a small side-question your project kept raising for me: **can a T-Box-less bike
give the phone any live vehicle data — fuel, RPM, gear, temps?** I ran it down on a **CFMoto 450NK
(2027, no T-Box)** using exactly the loop from §8 of `01-REVERSE-ENGINEERING.md` — read-only probes
in a debug build, against a live projecting bike, with verbose logging — and the answer is a clean
**no**, on every surface. Writing it up in case it saves someone else the sweep, and because it
**corrects one line in §6**.

Adds a single standalone doc, `docs/RE-VEHICLE-TELEMETRY.md`. No code, no app changes.

### What's in it

- **BLE: an undocumented service + it's an audio module.** The bike advertises
  `0000b360-d6d8-c7ec-bdf0-eab1bfc6bcbc` (char `b362`, WRITE|NOTIFY) — same vendor suffix as the
  wake-up `b354`, but a different service that `BleWakeUp` never sees (it matches by name, then looks
  only for `b354`). Device-info reads it as a **Feasycom FSC-BT1026**, a dual-mode BT audio module
  with a transparent-UART bridge — the hands-free/media path, not telemetry. Subscribed to its NOTIFY
  char for two 60 s windows while revving and toggling lights: **zero notifications.** So the §6 line
  calling the BLE "vehicle control (lock/telemetry)" is, at least on this unit, half right — it's
  audio, and it carries no telemetry.
- **PXC plane is screen/touch/voice only.** The one non-standard control frame I hadn't seen
  explained (`0x10470`) is the voice-command grammar; `RVINFO (0x60004110)` is a screen event
  (`sendRvInfo(ECPAppScreenEvent*)` in `librvserver.so`), not vehicle info.
- **The dash network, swept wide** (not a hand-picked port list): full TCP `1-65535` = **0 open**,
  UDP silent, **no broadcast/multicast beacon**, no mDNS services advertised.
- **The `0x104a0` SOCKS is outbound, not a way in.** It's the dash asking the *phone* to run a SOCKS
  server it dials out through for OTA (a T-Box-less dash has no internet of its own). I stood that
  server up and waited through a full session — the dash advertised it but **never connected**.

Conclusion: with no T-Box, no live vehicle data reaches the phone on BLE, PXC, or the dash network.
CFMoto gates telemetry behind the (paid) T-Box; the CAN bus at the diagnostic connector is the path
that has the data.

### Notes on the PR itself

- **Read-only throughout** — GATT enumerate, TCP/UDP connect, passive listen, and observe-and-forward
  on the SOCKS leg. Nothing was written to the vehicle.
- **Bike-specific identifiers redacted** (HUID, SN, VIN, MAC, the OTA password) — only mechanism is
  shared. `carbit_ota_user` is the generic Carbit account name, not bike-specific.
- Kept as a **standalone file** rather than editing your canonical `01-REVERSE-ENGINEERING.md`; if
  the `b360` correction or any of this is useful there, I'm glad to fold it into §6/§8 instead — your
  call. Happy to trim, expand, or drop anything.

Thanks for the clean-room docs — the §8 "ship a probe, run a bike session, read the log" loop is
what made this tractable.



---
> ↺ Re-creation of #22, which GitHub auto-closed when its source branch was rebuilt. Identical single-doc change, rebased onto current `main`.
